### PR TITLE
5606 Rotate depending on previous orientation

### DIFF
--- a/SwrveCommonSDK/src/main/java/com/swrve/sdk/SwrveImp.java
+++ b/SwrveCommonSDK/src/main/java/com/swrve/sdk/SwrveImp.java
@@ -189,6 +189,7 @@ abstract class SwrveImp<T, C extends SwrveConfigBase> {
     protected float device_dpi;
     protected float android_device_xdpi;
     protected float android_device_ydpi;
+    protected int previousOrientation;
     protected SwrveQAUser qaUser;
 
     public SwrveImp() {
@@ -996,6 +997,17 @@ abstract class SwrveImp<T, C extends SwrveConfigBase> {
         }
     }
 
+    protected void saveCurrentOrientation(Context ctx) {
+        try {
+            if (ctx != null) {
+                final Display display = ((WindowManager) ctx.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
+                previousOrientation = display.getRotation();
+            }
+        } catch(Exception exp) {
+            Log.e(LOG_TAG, "Could not obtain device orientation", exp);
+        }
+    }
+
     protected SwrveOrientation getDeviceOrientation() {
         Context ctx = context.get();
         if (ctx != null) {
@@ -1311,7 +1323,7 @@ abstract class SwrveImp<T, C extends SwrveConfigBase> {
                 if (dialog == null || !dialog.isShowing()) {
                     SwrveOrientation deviceOrientation = getDeviceOrientation();
                     Log.d(LOG_TAG, "Trying to show dialog with orientation " + deviceOrientation);
-                    SwrveMessageView swrveMessageView = SwrveMessageViewFactory.getInstance().buildLayout(activity, message, deviceOrientation, installButtonListener, customButtonListener, firstTime, config.getMinSampleSize());
+                    SwrveMessageView swrveMessageView = SwrveMessageViewFactory.getInstance().buildLayout(activity, message, deviceOrientation, previousOrientation, installButtonListener, customButtonListener, firstTime, config.getMinSampleSize());
                     SwrveDialog newDialog = new SwrveDialog(activity, message, swrveMessageView, R.style.SwrveDialogTheme);
                     newDialog.setOnDismissListener(new OnDismissListener() {
                         @Override
@@ -1325,6 +1337,7 @@ abstract class SwrveImp<T, C extends SwrveConfigBase> {
                             }
                         }
                     });
+                    saveCurrentOrientation(activity);
 
                     // Check if the customer wants to manage the dialog themselves
                     if (dialogListener != null) {

--- a/SwrveCommonSDK/src/main/java/com/swrve/sdk/messaging/view/SwrveMessageView.java
+++ b/SwrveCommonSDK/src/main/java/com/swrve/sdk/messaging/view/SwrveMessageView.java
@@ -76,28 +76,29 @@ public class SwrveMessageView extends RelativeLayout {
         super(context, attrs, defStyle);
     }
 
-    public SwrveMessageView(Context context, SwrveMessage message, SwrveMessageFormat format, boolean firstTime, boolean flip, int minSampleSize) throws SwrveMessageViewBuildException {
-        this(context, message, format, null, null, firstTime, flip, minSampleSize);
+    public SwrveMessageView(Context context, SwrveMessage message, SwrveMessageFormat format, boolean firstTime, int rotation, int minSampleSize) throws SwrveMessageViewBuildException {
+        this(context, message, format, null, null, firstTime, rotation, minSampleSize);
     }
 
-    public SwrveMessageView(Context context, SwrveMessage message, SwrveMessageFormat format, ISwrveInstallButtonListener installButtonListener, ISwrveCustomButtonListener customButtonListener, boolean firstTime, boolean flip, int minSampleSize) throws SwrveMessageViewBuildException {
+    public SwrveMessageView(Context context, SwrveMessage message, SwrveMessageFormat format, ISwrveInstallButtonListener installButtonListener, ISwrveCustomButtonListener customButtonListener, boolean firstTime, int rotation, int minSampleSize) throws SwrveMessageViewBuildException {
         super(context);
         this.message = message;
         this.format = format;
         this.firstTime = firstTime;
-        initializeLayout(context, message, format, installButtonListener, customButtonListener, flip, minSampleSize);
+        initializeLayout(context, message, format, installButtonListener, customButtonListener, rotation, minSampleSize);
     }
 
-    protected void initializeLayout(final Context context, final SwrveMessage message, final SwrveMessageFormat format, ISwrveInstallButtonListener installButtonListener, ISwrveCustomButtonListener customButtonListener, boolean flip, int minSampleSize) throws SwrveMessageViewBuildException {
+    protected void initializeLayout(final Context context, final SwrveMessage message, final SwrveMessageFormat format, ISwrveInstallButtonListener installButtonListener, ISwrveCustomButtonListener customButtonListener, int rotation, int minSampleSize) throws SwrveMessageViewBuildException {
         innerMessageView = new SwrveInnerMessageView(context, this, message, format, installButtonListener, customButtonListener, minSampleSize);
         setBackgroundColor(Color.BLACK);
         setGravity(Gravity.CENTER);
         setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
         addView(innerMessageView);
+        setClipChildren(false);
 
-        if (flip) {
+        if (rotation != 0) {
             // Flip internal message so that it can still fit in the screen
-            RotateAnimation rotate = new RotateAnimation(0, -90, Animation.RELATIVE_TO_SELF, 0.5f, Animation.RELATIVE_TO_SELF, 0.5f);
+            RotateAnimation rotate = new RotateAnimation(0, rotation, Animation.RELATIVE_TO_SELF, 0.5f, Animation.RELATIVE_TO_SELF, 0.5f);
             rotate.setFillAfter(true);
             innerMessageView.startAnimation(rotate);
         }

--- a/SwrveSDKDemo/AndroidManifest.xml
+++ b/SwrveSDKDemo/AndroidManifest.xml
@@ -17,7 +17,8 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
         <activity
-            android:name="com.swrve.sdk.demo.MainActivity">
+            android:name="com.swrve.sdk.demo.MainActivity"
+            android:screenOrientation="fullSensor">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/SwrveSDKDemo/res/layout/activity_main.xml
+++ b/SwrveSDKDemo/res/layout/activity_main.xml
@@ -106,7 +106,7 @@
                 android:layout_marginLeft="25dp"
                 android:layout_marginRight="25dp"
                 android:onClick="btnShowTalkMessage"
-                android:text="Show message for Swrve.user_purchase"
+                android:text="Show message for Swrve.Demo.OfferMessage"
                 android:textColor="#0000ff" />
         </LinearLayout>
     </LinearLayout>


### PR DESCRIPTION
Also, do not clip rotated message in parent (prevents from seeing full screen messages correctly if displayed format width != height).
https://swrvedev.jira.com/browse/SWRVE-5606
