### PR TITLE
10342 easier stack configuration

### DIFF
--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
@@ -117,8 +117,7 @@ public abstract class SwrveBase<T, C extends SwrveConfigBase> extends SwrveImp<T
             saveUniqueUserId(resolvedContext, userId);
             SwrveLogger.i(LOG_TAG, "Your user id is: " + userId);
 
-            // Generate default urls for the given app id
-            config.setAppIdPrefix(appId);
+            config.setUseHttpsForEventsUrl(true);
 
             if (SwrveHelper.isNullOrEmpty(config.getLanguage())) {
                 this.language = SwrveHelper.toLanguageTag(Locale.getDefault());

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
@@ -118,7 +118,7 @@ public abstract class SwrveBase<T, C extends SwrveConfigBase> extends SwrveImp<T
             SwrveLogger.i(LOG_TAG, "Your user id is: " + userId);
 
             // Generate default urls for the given app id
-            config.generateUrls(appId);
+            config.setAppIdPrefix(appId);
 
             if (SwrveHelper.isNullOrEmpty(config.getLanguage())) {
                 this.language = SwrveHelper.toLanguageTag(Locale.getDefault());

--- a/SwrveSDK/src/main/java/com/swrve/sdk/config/SwrveConfigBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/config/SwrveConfigBase.java
@@ -10,7 +10,6 @@ import com.swrve.sdk.messaging.SwrveOrientation;
 
 import java.io.File;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URL;
 import java.util.Locale;
 
@@ -89,9 +88,9 @@ public abstract class SwrveConfigBase {
 
 
     /**
-     * Current stack choice
+     * Current currentStack choice
      */
-    private SwrveStack stack = SwrveStack.US;
+    private SwrveStack currentStack = SwrveStack.US;
 
     /**
      * Session timeout time.
@@ -329,13 +328,13 @@ public abstract class SwrveConfigBase {
     }
 
     /**
-     * Based on the stack that has been chosen, return the correct prefix
+     * Based on the currentStack that has been chosen, return the correct prefix
      * @return
      */
     private String getStackPrefix(){
         String stackPrefix = "";
 
-        switch (stack){
+        switch (currentStack){
             case US:
                 // No prefixes
                 break;
@@ -389,7 +388,7 @@ public abstract class SwrveConfigBase {
         boolean generatingContentURL = eventOrContent.equalsIgnoreCase("content");
 
         // Set the appID prefix but only for supported stacks
-        boolean isAppIdSupportedStack  = (stack == SwrveStack.US || stack == SwrveStack.EU || stack == SwrveStack.ACTIVISION);
+        boolean isAppIdSupportedStack  = (currentStack == SwrveStack.US || currentStack == SwrveStack.EU || currentStack == SwrveStack.ACTIVISION);
         if (null != appIdPrefix && isAppIdSupportedStack){
             authority = Integer.toString(appIdPrefix) + ".";
         }
@@ -409,7 +408,7 @@ public abstract class SwrveConfigBase {
 
         String prefix = getStackPrefix();
 
-        // Set the stack prefix and host
+        // Set the currentStack prefix and host
         authority = authority + getStackPrefix() + endpoint;
         Uri uri = uriBuilder.scheme(scheme).authority(authority).build();
         URL newUrl = new URL(uri.toString());
@@ -422,24 +421,24 @@ public abstract class SwrveConfigBase {
 
 
     /**
-     * Simple helper method to setup the EU stack
+     * Simple helper method to setup the EU currentStack
      *
      * @return
      */
     public SwrveConfigBase useEuStack() throws MalformedURLException {
-        setStack(SwrveStack.EU);
+        setCurrentStack(SwrveStack.EU);
         regenerateURLS();
         return this;
     }
 
     /**
-     * Set the stack being currently used by the client
+     * Set the currentStack being currently used by the client
      * 
-     * @param stack
+     * @param currentStack
      * @return
      */
-    public SwrveConfigBase setStack(SwrveStack stack) throws MalformedURLException {
-        this.stack = stack;
+    public SwrveConfigBase setCurrentStack(SwrveStack currentStack) throws MalformedURLException {
+        this.currentStack = currentStack;
         regenerateURLS();
         return this;
     }

--- a/SwrveSDK/src/main/java/com/swrve/sdk/config/SwrveConfigBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/config/SwrveConfigBase.java
@@ -27,7 +27,7 @@ public abstract class SwrveConfigBase {
      * List of supported stacks
      */
     public enum SwrveStack{
-        EU, US, ACTIVISION, FEATURESTACK
+        EU, US
     }
 
     /**
@@ -80,12 +80,6 @@ public abstract class SwrveConfigBase {
      * Content and Events URL ID prefix
      */
     private Integer appIdPrefix;
-
-    /**
-     * Optional Featurestack Number if using featurestack
-     */
-    private Integer featureStackNum = 0;
-
 
     /**
      * Current currentStack choice
@@ -341,12 +335,6 @@ public abstract class SwrveConfigBase {
             case EU:
                 stackPrefix= "eu.";
                 break;
-            case ACTIVISION:
-                stackPrefix = "activision.";
-                break;
-            case FEATURESTACK:
-                stackPrefix = "featurestack" + Integer.toString(getFeatureStackNum()) + "-";
-                break;
         }
         return stackPrefix;
     }
@@ -388,8 +376,7 @@ public abstract class SwrveConfigBase {
         boolean generatingContentURL = eventOrContent.equalsIgnoreCase("content");
 
         // Set the appID prefix but only for supported stacks
-        boolean isAppIdSupportedStack  = (currentStack == SwrveStack.US || currentStack == SwrveStack.EU || currentStack == SwrveStack.ACTIVISION);
-        if (null != appIdPrefix && isAppIdSupportedStack){
+        if (null != appIdPrefix){
             authority = Integer.toString(appIdPrefix) + ".";
         }
 
@@ -439,24 +426,6 @@ public abstract class SwrveConfigBase {
      */
     public SwrveConfigBase setCurrentStack(SwrveStack currentStack) throws MalformedURLException {
         this.currentStack = currentStack;
-        generateURLS();
-        return this;
-    }
-
-    /**
-     * @return
-     */
-    public Integer getFeatureStackNum() {
-        return featureStackNum;
-    }
-
-    /**
-     *
-     * @param featureStackNum
-     * @return
-     */
-    public SwrveConfigBase setFeatureStackNum(Integer featureStackNum) {
-        this.featureStackNum = featureStackNum;
         generateURLS();
         return this;
     }

--- a/SwrveSDK/src/main/java/com/swrve/sdk/config/SwrveConfigBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/config/SwrveConfigBase.java
@@ -24,13 +24,6 @@ public abstract class SwrveConfigBase {
     private final String LOG_TAG = "SwrveConfigBase";
 
     /**
-     * List of supported stacks
-     */
-    public enum SwrveStack{
-        EU, US
-    }
-
-    /**
      * Custom unique user id.
      */
     private String userId;

--- a/SwrveSDK/src/main/java/com/swrve/sdk/config/SwrveConfigBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/config/SwrveConfigBase.java
@@ -154,6 +154,11 @@ public abstract class SwrveConfigBase {
      * Create an instance of the SDK advance preferences.
      */
     public SwrveConfigBase() {
+        try {
+            this.setCurrentStack(SwrveStack.US);
+        }catch(MalformedURLException e){
+            SwrveLogger.wtf(LOG_TAG, "Failed to initialize SwrveConfig.", e);
+        }
     }
 
     /**

--- a/SwrveSDK/src/main/java/com/swrve/sdk/config/SwrveConfigBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/config/SwrveConfigBase.java
@@ -22,7 +22,6 @@ public abstract class SwrveConfigBase {
     /**
      * Default Log Tag
      */
-
     private final String LOG_TAG = "SwrveConfigBase";
 
     /**
@@ -379,6 +378,7 @@ public abstract class SwrveConfigBase {
 
     /**
      * Using the information and flags provided in the class, generate the content URLS
+     *
      * @param eventOrContent
      * @throws MalformedURLException
      */
@@ -422,6 +422,8 @@ public abstract class SwrveConfigBase {
 
 
     /**
+     * Simple helper method to setup the EU stack
+     *
      * @return
      */
     public SwrveConfigBase useEuStack() throws MalformedURLException {
@@ -432,6 +434,7 @@ public abstract class SwrveConfigBase {
 
     /**
      * Set the stack being currently used by the client
+     * 
      * @param stack
      * @return
      */

--- a/SwrveSDK/src/main/java/com/swrve/sdk/config/SwrveConfigBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/config/SwrveConfigBase.java
@@ -352,25 +352,25 @@ public abstract class SwrveConfigBase {
     }
 
     /**
-     * Unless the user/developer has already set the content or event url, regenerate the urls based on config information.
+     * Unless the user/developer has already set the content or event url, generate the urls based on config information.
      *
      * @return
      * @throws MalformedURLException
      */
-    private SwrveConfigBase regenerateURLS() {
+    private SwrveConfigBase generateURLS() {
         try {
             if (userOverrideContentUrl) {
-                SwrveLogger.warn("Contents Url has already been set by developer. Will not regenerate url");
+                SwrveLogger.warn("Contents Url has already been set by developer. Will not generate url");
             } else {
-                regenerateUrlFor("content");
+                generateUrlFor("content");
             }
             if (userOverrideEventUrl) {
-                SwrveLogger.warn("Events Url has already been set by developer. Will not regenerate url");
+                SwrveLogger.warn("Events Url has already been set by developer. Will not generate url");
             } else {
-                regenerateUrlFor("event");
+                generateUrlFor("event");
             }
         } catch (MalformedURLException e) {
-            SwrveLogger.e(LOG_TAG, "Could not regenerate URLS for config ", e);
+            SwrveLogger.e(LOG_TAG, "Could not generate URLS for config ", e);
         }
         return this;
     }
@@ -381,7 +381,7 @@ public abstract class SwrveConfigBase {
      * @param eventOrContent
      * @throws MalformedURLException
      */
-    private void regenerateUrlFor(String eventOrContent) throws MalformedURLException {
+    private void generateUrlFor(String eventOrContent) throws MalformedURLException {
         Uri.Builder uriBuilder = new Uri.Builder();
         String authority = "";
         boolean generatingEventURL = eventOrContent.equalsIgnoreCase("event");
@@ -427,7 +427,7 @@ public abstract class SwrveConfigBase {
      */
     public SwrveConfigBase useEuStack() throws MalformedURLException {
         setCurrentStack(SwrveStack.EU);
-        regenerateURLS();
+        generateURLS();
         return this;
     }
 
@@ -439,7 +439,7 @@ public abstract class SwrveConfigBase {
      */
     public SwrveConfigBase setCurrentStack(SwrveStack currentStack) throws MalformedURLException {
         this.currentStack = currentStack;
-        regenerateURLS();
+        generateURLS();
         return this;
     }
 
@@ -457,7 +457,7 @@ public abstract class SwrveConfigBase {
      */
     public SwrveConfigBase setFeatureStackNum(Integer featureStackNum) {
         this.featureStackNum = featureStackNum;
-        regenerateURLS();
+        generateURLS();
         return this;
     }
 
@@ -475,7 +475,7 @@ public abstract class SwrveConfigBase {
      */
     public SwrveConfigBase setAppIdPrefix(Integer appIdPrefix) {
         this.appIdPrefix = appIdPrefix;
-        regenerateURLS();
+        generateURLS();
         return this;
     }
 
@@ -559,7 +559,7 @@ public abstract class SwrveConfigBase {
      */
     public SwrveConfigBase setUseHttpsForEventsUrl(boolean useHttpsForEventsUrl) {
         this.useHttpsForEventsUrl = useHttpsForEventsUrl;
-        regenerateURLS();
+        generateURLS();
         return this;
     }
 
@@ -577,7 +577,7 @@ public abstract class SwrveConfigBase {
      */
     public SwrveConfigBase setUseHttpsForContentUrl(boolean useHttpsForContentUrl) {
         this.useHttpsForContentUrl = useHttpsForContentUrl;
-        regenerateURLS();
+        generateURLS();
         return this;
     }
 

--- a/SwrveSDK/src/main/java/com/swrve/sdk/config/SwrveConfigBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/config/SwrveConfigBase.java
@@ -77,11 +77,6 @@ public abstract class SwrveConfigBase {
     private boolean userOverrideContentUrl = false;
 
     /**
-     * Content and Events URL ID prefix
-     */
-    private Integer appIdPrefix;
-
-    /**
      * Current currentStack choice
      */
     private SwrveStack currentStack = SwrveStack.US;
@@ -375,11 +370,6 @@ public abstract class SwrveConfigBase {
         boolean generatingEventURL = eventOrContent.equalsIgnoreCase("event");
         boolean generatingContentURL = eventOrContent.equalsIgnoreCase("content");
 
-        // Set the appID prefix but only for supported stacks
-        if (null != appIdPrefix){
-            authority = Integer.toString(appIdPrefix) + ".";
-        }
-
         // Host and Scheme to target
         String scheme, endpoint;
         if (generatingEventURL){
@@ -396,7 +386,7 @@ public abstract class SwrveConfigBase {
         String prefix = getStackPrefix();
 
         // Set the currentStack prefix and host
-        authority = authority + getStackPrefix() + endpoint;
+        authority = getStackPrefix() + endpoint;
         Uri uri = uriBuilder.scheme(scheme).authority(authority).build();
         URL newUrl = new URL(uri.toString());
         if (generatingContentURL){
@@ -426,24 +416,6 @@ public abstract class SwrveConfigBase {
      */
     public SwrveConfigBase setCurrentStack(SwrveStack currentStack) throws MalformedURLException {
         this.currentStack = currentStack;
-        generateURLS();
-        return this;
-    }
-
-    /**
-     * @return
-     */
-    public Integer getAppIdPrefix() {
-        return appIdPrefix;
-    }
-
-    /**
-     *
-     * @param appIdPrefix
-     * @return
-     */
-    public SwrveConfigBase setAppIdPrefix(Integer appIdPrefix) {
-        this.appIdPrefix = appIdPrefix;
         generateURLS();
         return this;
     }

--- a/SwrveSDK/src/main/java/com/swrve/sdk/config/SwrveStack.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/config/SwrveStack.java
@@ -1,0 +1,6 @@
+package com.swrve.sdk.config;
+
+public enum SwrveStack {
+    EU, US
+}
+

--- a/SwrveSDKDemo/src/com/swrve/sdk/demo/DemoApplication.java
+++ b/SwrveSDKDemo/src/com/swrve/sdk/demo/DemoApplication.java
@@ -4,11 +4,6 @@ import android.app.Application;
 import android.util.Log;
 
 import com.swrve.sdk.SwrveSDK;
-import com.swrve.sdk.config.SwrveConfig;
-import com.swrve.sdk.config.SwrveConfigBase;
-
-import java.net.MalformedURLException;
-import java.net.URL;
 
 public class DemoApplication extends Application {
 
@@ -18,23 +13,8 @@ public class DemoApplication extends Application {
     public void onCreate() {
         super.onCreate();
 
-        SwrveConfig config = new SwrveConfig();
-
         try {
-            config.useEuStack();
-            config.setStack(SwrveConfigBase.SwrveStack.US);
-            config.setAppIdPrefix(2132);
-            config.setUseHttpsForEventsUrl(true);
-            config.setEventsUrl(new URL("https://featurestack12-api.swrve.com")); // Calling these directly should lock them
-            config.setContentUrl(new URL("https://featurestack12-content.swrve.com"));
-            config.setUseHttpsForEventsUrl(false); // Should still be http
-            config.setStack(SwrveConfigBase.SwrveStack.US); // Should still be featurestack 12
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        }
-
-        try {
-            SwrveSDK.createInstance(this, 2132, "AYgy6V2uk6f3d46ShfJ", config);
+            SwrveSDK.createInstance(this, YOUR_APP_ID, YOUR_API_KEY);
         } catch (IllegalArgumentException exp) {
             Log.e(LOG_TAG, "Could not initialize the Swrve SDK", exp);
         }

--- a/SwrveSDKDemo/src/com/swrve/sdk/demo/DemoApplication.java
+++ b/SwrveSDKDemo/src/com/swrve/sdk/demo/DemoApplication.java
@@ -4,6 +4,11 @@ import android.app.Application;
 import android.util.Log;
 
 import com.swrve.sdk.SwrveSDK;
+import com.swrve.sdk.config.SwrveConfig;
+import com.swrve.sdk.config.SwrveConfigBase;
+
+import java.net.MalformedURLException;
+import java.net.URL;
 
 public class DemoApplication extends Application {
 
@@ -13,8 +18,23 @@ public class DemoApplication extends Application {
     public void onCreate() {
         super.onCreate();
 
+        SwrveConfig config = new SwrveConfig();
+
         try {
-            SwrveSDK.createInstance(this, YOUR_APP_ID, YOUR_API_KEY);
+            config.useEuStack();
+            config.setStack(SwrveConfigBase.SwrveStack.US);
+            config.setAppIdPrefix(2132);
+            config.setUseHttpsForEventsUrl(true);
+            config.setEventsUrl(new URL("https://featurestack12-api.swrve.com")); // Calling these directly should lock them
+            config.setContentUrl(new URL("https://featurestack12-content.swrve.com"));
+            config.setUseHttpsForEventsUrl(false); // Should still be http
+            config.setStack(SwrveConfigBase.SwrveStack.US); // Should still be featurestack 12
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            SwrveSDK.createInstance(this, 2132, "AYgy6V2uk6f3d46ShfJ", config);
         } catch (IllegalArgumentException exp) {
             Log.e(LOG_TAG, "Could not initialize the Swrve SDK", exp);
         }


### PR DESCRIPTION
Can now call setStack which will make it easier for developers to switch between stacks and not have to specific content or event urls manually.

Also a utility method `config.useEUStack()` which will set everything up automatically.