### PR TITLE
Fix for location of Android maven package

### DIFF
--- a/SwrveSDK/build.gradle
+++ b/SwrveSDK/build.gradle
@@ -39,6 +39,12 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 publishing {
+    repositories {
+        maven {
+            url "$buildDir/../publish" // SwrveSDK/publish
+        }
+    }
+
     publications {
         core(MavenPublication) {
             artifactId swrveCoreArtifactId


### PR DESCRIPTION
Looks like at some point the rake and gradle tasks stopped publishing aar and POM files. I've updated the gradle task to put them in the SwrveSDK/publish directory