### PR TITLE
10959-Only send impression events from background service and make thread safe

### DIFF
--- a/SwrveSDK/src/main/java/com/swrve/sdk/EventHelper.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/EventHelper.java
@@ -16,7 +16,7 @@ import java.util.Random;
 final class EventHelper {
     private static final Object BATCH_API_VERSION = "2";
 
-    private synchronized static short getDeviceId(MemoryCachedLocalStorage storage) {
+    protected synchronized static short getDeviceId(MemoryCachedLocalStorage storage) {
         String id = storage.getSharedCacheEntry("device_id");
         if (id == null || id.length() <= 0) {
             short deviceId = (short) new Random().nextInt(Short.MAX_VALUE);
@@ -64,17 +64,14 @@ final class EventHelper {
      * Generate JSON in the format expected by the batch API to inform Swrve of
      * these events.
      */
-    public static String eventsAsBatch(String userId, String appVersion,
-                                       String sessionToken, LinkedHashMap<Long, String> events, MemoryCachedLocalStorage storage)
-            throws JSONException {
+    public static String eventsAsBatch(LinkedHashMap<Long, String> events, String userId, String appVersion, String sessionToken, short deviceId) throws JSONException {
         JSONObject batch = new JSONObject();
         batch.put("user", userId);
         batch.put("session_token", sessionToken);
         batch.put("version", BATCH_API_VERSION);
         batch.put("app_version", appVersion);
-        batch.put("device_id", getDeviceId(storage));
+        batch.put("device_id", deviceId);
         batch.put("data", orderedMapToJSONArray(events));
-
         return batch.toString();
     }
 

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SendEventsManager.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SendEventsManager.java
@@ -3,37 +3,82 @@ package com.swrve.sdk;
 import com.swrve.sdk.config.SwrveConfigBase;
 import com.swrve.sdk.localstorage.ILocalStorage;
 import com.swrve.sdk.localstorage.MemoryCachedLocalStorage;
+import com.swrve.sdk.localstorage.SQLiteLocalStorage;
 import com.swrve.sdk.rest.IRESTClient;
 import com.swrve.sdk.rest.IRESTResponseListener;
 import com.swrve.sdk.rest.RESTResponse;
 
 import org.json.JSONException;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
-public class QueuedEventsManager {
+public class SendEventsManager {
 
-    protected static final String LOG_TAG = "SwrveSDK";
+    private static final String LOG_TAG = "SwrveSDK";
+    private static final Object lock = new Object();
 
     private final SwrveConfigBase config;
+    private final IRESTClient restClient;
     private final String userId;
     private final String appVersion;
     private final String sessionToken;
-    private final IRESTClient restClient;
+    private final short deviceId;
 
-    protected QueuedEventsManager(SwrveConfigBase config, IRESTClient restClient, String userId, String appVersion, String sessionToken){
+    protected SendEventsManager(SwrveConfigBase config, IRESTClient restClient, String userId, String appVersion, String sessionToken, short deviceId) {
         this.config = config;
         this.restClient = restClient;
         this.userId = userId;
         this.appVersion = appVersion;
         this.sessionToken = sessionToken;
+        this.deviceId = deviceId;
     }
 
-    protected int sendQueuedEvents(MemoryCachedLocalStorage cachedLocalStorage) {
+    /*
+     * Stores the events passed in from ArrayList and attempts to send only these events. If successful, these events are removed from storage.
+     */
+    protected int storeAndSendEvents(ArrayList<String> events, MemoryCachedLocalStorage memoryCachedLocalStorage, SQLiteLocalStorage sqLiteLocalStorage) throws Exception {
+        if (events != null && events.size() == 0) {
+            return 0;
+        }
+        synchronized(lock) {
+            LinkedHashMap<Long, String> storedEvents = storeEvents(events, memoryCachedLocalStorage, sqLiteLocalStorage);
+
+            LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>> combinedEvents = new LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>>();
+            combinedEvents.put(memoryCachedLocalStorage, storedEvents);
+            return sendEvents(combinedEvents);
+        }
+    }
+
+    private LinkedHashMap<Long, String> storeEvents(ArrayList<String> events,
+                                                    MemoryCachedLocalStorage memoryCachedLocalStorage, SQLiteLocalStorage sqLiteLocalStorage) throws Exception {
+        LinkedHashMap<Long, String> storedEvents = new LinkedHashMap<Long, String>();
+        for (String event : events) {
+            Map<String, Object> parameters = new HashMap<String, Object>();
+            parameters.put("name", event);
+
+            String eventAsJSON = EventHelper.eventAsJSON("event", parameters, null, memoryCachedLocalStorage);
+            long id = sqLiteLocalStorage.addEventAndGetId(eventAsJSON);
+            storedEvents.put(id, eventAsJSON);
+        }
+        return storedEvents;
+    }
+
+    /*
+     * Attempts to sends events from local storage and deletes them if successful. Number of events sent configured from config.
+     */
+    protected int sendStoredEvents(MemoryCachedLocalStorage cachedLocalStorage) {
+        synchronized(lock) {
+            final LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>> combinedEvents = cachedLocalStorage.getCombinedFirstNEvents(config.getMaxEventsPerFlush());
+            return sendEvents(combinedEvents);
+        }
+    }
+
+    private int sendEvents(final LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>> combinedEvents) {
         int eventsSent = 0;
-        // Get batch of events and send them
-        final LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>> combinedEvents = cachedLocalStorage.getCombinedFirstNEvents(config.getMaxEventsPerFlush());
         final LinkedHashMap<Long, String> events = new LinkedHashMap<Long, String>();
         if (!combinedEvents.isEmpty()) {
             SwrveLogger.i(LOG_TAG, "Sending queued events");
@@ -44,7 +89,7 @@ public class QueuedEventsManager {
                     events.putAll(combinedEvents.get(storageIt.next()));
                 }
                 eventsSent = events.size();
-                String data = com.swrve.sdk.EventHelper.eventsAsBatch(userId, appVersion, sessionToken, events, cachedLocalStorage);
+                String data = EventHelper.eventsAsBatch(events, userId, appVersion, sessionToken, deviceId);
                 SwrveLogger.i(LOG_TAG, "Sending " + events.size() + " events to Swrve");
                 postBatchRequest(data, new IPostBatchRequestListener() {
                     public void onResponse(boolean shouldDelete) {
@@ -61,13 +106,13 @@ public class QueuedEventsManager {
                     }
                 });
             } catch (JSONException je) {
-                SwrveLogger.e(LOG_TAG, "Unable to generate event batch", je);
+                SwrveLogger.e(LOG_TAG, "Unable to generate event batch, and send events", je);
             }
         }
         return eventsSent;
     }
 
-    protected void postBatchRequest(String postData, final IPostBatchRequestListener listener) {
+    private void postBatchRequest(final String postData, final IPostBatchRequestListener listener) {
 
         restClient.post(config.getEventsUrl() + SwrveBase.BATCH_EVENTS_ACTION, postData, new IRESTResponseListener() {
             @Override
@@ -88,7 +133,7 @@ public class QueuedEventsManager {
 
             @Override
             public void onException(Exception ex) {
-                SwrveLogger.e(LOG_TAG, "Error posting batch of events.", ex);
+                SwrveLogger.e(LOG_TAG, "Error posting batch of events. postData:" + postData, ex);
             }
         });
     }

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
@@ -405,8 +405,8 @@ public abstract class SwrveBase<T, C extends SwrveConfigBase> extends SwrveImp<T
                 @Override
                 public void run() {
                     short deviceId = EventHelper.getDeviceId(cachedLocalStorage);
-                    SendEventsManager sendEventsManager = new SendEventsManager(config, restClient, userId, appVersion, sessionToken, deviceId);
-                    sendEventsManager.sendStoredEvents(cachedLocalStorage);
+                    SwrveEventsManager swrveEventsManager = new SwrveEventsManager(config, restClient, userId, appVersion, sessionToken, deviceId);
+                    swrveEventsManager.sendStoredEvents(cachedLocalStorage);
                     eventsWereSent = true;
                 }
             });

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
@@ -404,8 +404,10 @@ public abstract class SwrveBase<T, C extends SwrveConfigBase> extends SwrveImp<T
             restClientExecutorExecute(new Runnable() {
                 @Override
                 public void run() {
-                    QueuedEventsManager queuedEventsManager = new QueuedEventsManager(config, restClient, userId, appVersion, sessionToken);
-                    eventsWereSent = queuedEventsManager.sendQueuedEvents(cachedLocalStorage) > 0;
+                    short deviceId = EventHelper.getDeviceId(cachedLocalStorage);
+                    SendEventsManager sendEventsManager = new SendEventsManager(config, restClient, userId, appVersion, sessionToken, deviceId);
+                    sendEventsManager.sendStoredEvents(cachedLocalStorage);
+                    eventsWereSent = true;
                 }
             });
         }

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveEventsManager.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveEventsManager.java
@@ -16,7 +16,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class SendEventsManager {
+public class SwrveEventsManager {
 
     private static final String LOG_TAG = "SwrveSDK";
     private static final Object lock = new Object();
@@ -28,7 +28,7 @@ public class SendEventsManager {
     private final String sessionToken;
     private final short deviceId;
 
-    protected SendEventsManager(SwrveConfigBase config, IRESTClient restClient, String userId, String appVersion, String sessionToken, short deviceId) {
+    protected SwrveEventsManager(SwrveConfigBase config, IRESTClient restClient, String userId, String appVersion, String sessionToken, short deviceId) {
         this.config = config;
         this.restClient = restClient;
         this.userId = userId;

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveWakefulService.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveWakefulService.java
@@ -57,8 +57,8 @@ public class SwrveWakefulService extends IntentService {
             sqLiteLocalStorage = new SQLiteLocalStorage(getApplicationContext(), swrve.config.getDbName(), swrve.config.getMaxSqliteDbSize());
             memoryCachedLocalStorage = new MemoryCachedLocalStorage(sqLiteLocalStorage, null);
 
-            SendEventsManager sendEventsManager = getSendEventsManager(memoryCachedLocalStorage);
-            eventsSent = sendEventsManager.storeAndSendEvents(events, memoryCachedLocalStorage, sqLiteLocalStorage);
+            SwrveEventsManager swrveEventsManager = getSendEventsManager(memoryCachedLocalStorage);
+            eventsSent = swrveEventsManager.storeAndSendEvents(events, memoryCachedLocalStorage, sqLiteLocalStorage);
         } finally {
             if (sqLiteLocalStorage != null) sqLiteLocalStorage.close();
             if (memoryCachedLocalStorage != null) memoryCachedLocalStorage.close();
@@ -67,10 +67,10 @@ public class SwrveWakefulService extends IntentService {
         return eventsSent;
     }
 
-    private SendEventsManager getSendEventsManager(MemoryCachedLocalStorage memoryCachedLocalStorage){
+    private SwrveEventsManager getSendEventsManager(MemoryCachedLocalStorage memoryCachedLocalStorage){
         IRESTClient restClient = new RESTClient(swrve.config.getHttpTimeout());
         short deviceId = EventHelper.getDeviceId(memoryCachedLocalStorage);
         String sessionToken = SwrveHelper.generateSessionToken(swrve.apiKey, swrve.appId, swrve.userId);
-        return new SendEventsManager(swrve.config, restClient, swrve.userId, swrve.appVersion, sessionToken, deviceId);
+        return new SwrveEventsManager(swrve.config, restClient, swrve.userId, swrve.appVersion, sessionToken, deviceId);
     }
 }

--- a/SwrveSDK/src/main/java/com/swrve/sdk/localstorage/SQLiteLocalStorage.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/localstorage/SQLiteLocalStorage.java
@@ -56,11 +56,17 @@ public class SQLiteLocalStorage implements ILocalStorage, IFastInsertLocalStorag
     }
 
     public void addEvent(String eventJSON) throws SQLException {
+        addEventAndGetId(eventJSON);
+    }
+
+    public long addEventAndGetId(String eventJSON) throws SQLException {
+        long rowId = 0;
         if (connectionOpen.get()) {
             ContentValues values = new ContentValues();
             values.put(COLUMN_EVENT, eventJSON);
-            database.insertOrThrow(TABLE_EVENTS_JSON, null, values);
+            rowId = database.insertOrThrow(TABLE_EVENTS_JSON, null, values);
         }
+        return rowId;
     }
 
     public void removeEventsById(Collection<Long> ids) {


### PR DESCRIPTION
https://swrvedev.jira.com/browse/SWRVE-10959

@shanetmoore Further changes to my original PR. These changes allow new events to be stored and only send those new events. 

Also made it thread safe. 
