### PR TITLE
process push notifications on init

### DIFF
--- a/SwrveSDK/src/core/java/com/swrve/sdk/Swrve.java
+++ b/SwrveSDK/src/core/java/com/swrve/sdk/Swrve.java
@@ -34,6 +34,7 @@ public class Swrve extends SwrveBase<ISwrve, SwrveConfig> implements ISwrve {
 
     @Override
     protected void afterInit() {
+        afterBind();
     }
 
     @Override

--- a/SwrveSDK/src/google/java/com/swrve/sdk/Swrve.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/Swrve.java
@@ -97,6 +97,8 @@ public class Swrve extends SwrveBase<ISwrve, SwrveConfig> implements ISwrve {
 
     @Override
     protected void afterInit() {
+        // process push notifications
+        afterBind();
     }
 
     @Override


### PR DESCRIPTION
While doing push notification integration in my app, I noticed that push notification payloads were not getting processed when the notification launched the app.  It appears this logic was simply getting skipped  on launch (init) while correctly being executed onResume.  

This may not be the best placement for the afterBind() call, but it certainly fixes the bug in question in my application.  Please let me know what you think.
