### PR TITLE
Send more than one push notification to QAUsers.

### DIFF
--- a/SwrveSDK/src/google/java/com/swrve/sdk/Swrve.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/Swrve.java
@@ -259,13 +259,19 @@ public class Swrve extends SwrveBase<ISwrve, SwrveConfig> implements ISwrve {
                     // Obtain push id
                     Object rawId = msg.get("_p");
                     String msgId = (rawId != null) ? rawId.toString() : null;
-                    // Only process once the message if possible
-                    if (!SwrveHelper.isNullOrEmpty(msgId) && (lastProcessedMessage == null || !lastProcessedMessage.equals(msgId))) {
-                        lastProcessedMessage = msgId;
-                        _event("Swrve.Messages.Push-" + msgId + ".engaged", null);
-                        // Call custom listener
+                    if(qaUser!=null && !SwrveHelper.isNullOrEmpty(msgId)){
                         if (pushNotificationListener != null) {
                             pushNotificationListener.onPushNotification(msg);
+                        }
+                    }else {
+                        // Only process once the message if possible
+                        if (!SwrveHelper.isNullOrEmpty(msgId) && (lastProcessedMessage == null || !lastProcessedMessage.equals(msgId))) {
+                            lastProcessedMessage = msgId;
+                            _event("Swrve.Messages.Push-" + msgId + ".engaged", null);
+                            // Call custom listener
+                            if (pushNotificationListener != null) {
+                                pushNotificationListener.onPushNotification(msg);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
From Campaigns/Push Notifications on Preview & Test we cand fire
onPushNotification listeners again and again to QA users.
With this code we don't send any tracking engagement if we are
a qa user.

This a good update for developers because we don't have to create
multiple campaigns to test the push notification integration.
