### PR TITLE
message_center_null_subject

### DIFF
--- a/SwrveSDK/src/main/java/com/swrve/sdk/messaging/SwrveBaseCampaign.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/messaging/SwrveBaseCampaign.java
@@ -70,7 +70,7 @@ public abstract class SwrveBaseCampaign {
         this();
         setId(campaignData.getInt("id"));
         setMessageCenter(campaignData.optBoolean("message_center", false));
-        setSubject(campaignData.optString("subject", null));
+        setSubject(campaignData.isNull("subject") ? "" : campaignData.getString("subject"));
         setTalkController(controller);
         SwrveLogger.i(LOG_TAG, "Loading campaign " + getId());
 


### PR DESCRIPTION
If the subject in message center is null, then a blank string is assigned.
