### PR TITLE
Let Swrve use app's own GCM registrationId token

### DIFF
--- a/SwrveSDK/src/google/java/com/swrve/sdk/ISwrve.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/ISwrve.java
@@ -19,4 +19,6 @@ public interface ISwrve extends ISwrveBase<ISwrve, SwrveConfig> {
     void processIntent(Intent intent);
 
     void onTokenRefreshed();
+
+    void setRegistrationId(String gcmRegistrationId);
 }

--- a/SwrveSDK/src/google/java/com/swrve/sdk/SwrveEmpty.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/SwrveEmpty.java
@@ -34,4 +34,8 @@ public class SwrveEmpty extends SwrveBaseEmpty<ISwrve, SwrveConfig> implements I
     @Override
     public void processIntent(Intent intent) {
     }
+
+    @Override
+    public void setRegistrationId(String gcmRegistrationId) {
+    }
 }

--- a/SwrveSDK/src/google/java/com/swrve/sdk/SwrveSDK.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/SwrveSDK.java
@@ -11,6 +11,7 @@ public class SwrveSDK extends SwrveSDKBase {
 
     /**
      * Create a single Swrve SDK instance.
+     *
      * @param context your activity or application context
      * @param appId   your app id in the Swrve dashboard
      * @param apiKey  your app api_key in the Swrve dashboard
@@ -22,6 +23,7 @@ public class SwrveSDK extends SwrveSDKBase {
 
     /**
      * Create a single Swrve SDK instance.
+     *
      * @param context your activity or application context
      * @param appId   your app id in the Swrve dashboard
      * @param apiKey  your app api_key in the Swrve dashboard
@@ -88,7 +90,7 @@ public class SwrveSDK extends SwrveSDKBase {
      * Add a Swrve.iap event to the event queue. This event should be added for unvalidated real
      * money transactions in the Google Play Store, where in-app currency was purchased
      * or where multiple items and/or currencies were purchased.
-     *
+     * <p>
      * To create the rewards object, create an instance of SwrveIAPRewards and
      * use addItem() and addCurrency() to add the individual rewards
      *
@@ -126,5 +128,18 @@ public class SwrveSDK extends SwrveSDKBase {
     public static void processIntent(Intent intent) {
         checkInstanceCreated();
         ((ISwrve) instance).processIntent(intent);
+    }
+
+    /**
+     * Manually set the GCM registration ID.
+     * <p>
+     * Make sure to init Swrve with {@code SwrveConfig.provideOwnGcmRegistrationId();}
+     * if you want to use this method.
+     *
+     * @param registrationId the GCM registration token received after your app registers to GCM
+     */
+    public static void setGcmRegistrationId(String registrationId) {
+        checkInstanceCreated();
+        ((ISwrve) instance).setRegistrationId(registrationId);
     }
 }

--- a/SwrveSDK/src/google/java/com/swrve/sdk/config/SwrveConfig.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/config/SwrveConfig.java
@@ -23,7 +23,7 @@ public class SwrveConfig extends SwrveConfigBase {
     private boolean gGcmPushEnabled;
 
     /**
-     * Whether the Swrve SDK should register to GCM (true) or let the app handles it (false)
+     * Whether the Swrve SDK should register to GCM (true) or let the app handle it (false)
      */
     private boolean performGcmRegistrationInternally;
 

--- a/SwrveSDK/src/google/java/com/swrve/sdk/config/SwrveConfig.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/config/SwrveConfig.java
@@ -18,6 +18,16 @@ public class SwrveConfig extends SwrveConfigBase {
     private boolean gAIDLoggingEnabled;
 
     /**
+     * Whether the Swrve SDK should handle GCM pushes
+     */
+    private boolean gGcmPushEnabled;
+
+    /**
+     * Whether the Swrve SDK should register to GCM (true) or let the app handles it (false)
+     */
+    private boolean performGcmRegistrationInternally;
+
+    /**
      * Returns an instance of SwrveConfig with the Sender id.
      *
      * @param senderId
@@ -39,6 +49,21 @@ public class SwrveConfig extends SwrveConfigBase {
      */
     public SwrveConfig setSenderId(String senderId) {
         this.senderId = senderId;
+        this.gGcmPushEnabled = !SwrveHelper.isNullOrEmpty(senderId);
+        this.performGcmRegistrationInternally = true;
+        return this;
+    }
+
+    /**
+     * Let your app handle GCM registration instead of Swrve
+     * <p>
+     * When calling this method, the Swrve SDK expects your app to register to
+     * GCM and then send Swrve the registration token via
+     * {@code SwrveSDK.setGcmRegistrationId(registrationId);}
+     */
+    public SwrveConfig provideOwnGcmRegistrationId() {
+        this.gGcmPushEnabled = true;
+        this.performGcmRegistrationInternally = false;
         return this;
     }
 
@@ -46,14 +71,14 @@ public class SwrveConfig extends SwrveConfigBase {
      * @return if push is enabled.
      */
     public boolean isPushEnabled() {
-        return !SwrveHelper.isNullOrEmpty(this.senderId);
+        return gGcmPushEnabled;
     }
 
     /**
      * @return if it will automatically log Google's Advertising Id as "swrve.GAID".
      */
     public boolean isGAIDLoggingEnabled() {
-            return gAIDLoggingEnabled;
+        return gAIDLoggingEnabled;
     }
 
     /**
@@ -61,5 +86,12 @@ public class SwrveConfig extends SwrveConfigBase {
      */
     public void setGAIDLoggingEnabled(boolean enabled) {
         this.gAIDLoggingEnabled = enabled;
+    }
+
+    /**
+     * @return if the Swrve SDK registers for gcm pushes by itself.
+     */
+    public boolean isPushRegistrationDoneBySwrve() {
+        return performGcmRegistrationInternally;
     }
 }


### PR DESCRIPTION
Idea is for an app that already uses GCM to send its own GCM registrationId token to Swrve instead of letting Swrve do the GCM registration and have its own token.

When initializing Swrve, an app should call the following:

``` java
SwrveConfig config = new SwrveConfig();
config.provideOwnGcmRegistrationId();
SwrveSDK.createInstance(context, APP_ID, API_KEY, config);
```

Then, the app must handle the GCM registration on its own (with `InstanceID.getInstance(context).getToken()`) and send the received token to Swrve with:

``` java
SwrveSDK.setGcmRegistrationId(registrationId);
```

The app should, of course, keep the `SwrveGcmIntentService` defined in its `AndroidManifest.xml`, and also have the `SwrveIdentifyPushesBroadcastListener` (as specified in your documentation). The `SwrveGcmInstanceIDListenerService` is no longer necessary, as it is the app's responsibility to deal with expired tokens and send back the new one to Swrve with `SwrveSDK.setGcmRegistrationId(registrationId);`.
### Why this PR?

We had some concurrency issues with GCM registrations: When our app is started (first launch), it registers to GCM, but Swrve also does this similar process. We noticed that, when two GCM registrations (even with different SENDER_ID) are done at the same time, the tokens we received are usually invalid (their status is "NotRegistered). When doing the 2 GCM registrations sequentially (e.g. when using some breakpoints to slow down the registration process making sure Swrve receives its token, then our app), the tokens are valid.
We did not modify the code, only slowed down the registration process.

Here, we only want only our app to perform the GCM registration, not Swrve. When the gcm registration succeeds, we send you our registration token.

We don't have GCM issues anymore when using this modified version of Swrve.
