### PR TITLE
added getRegistrationId and made it public

### DIFF
--- a/SwrveSDK/src/google/java/com/swrve/sdk/ISwrve.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/ISwrve.java
@@ -19,4 +19,6 @@ public interface ISwrve extends ISwrveBase<ISwrve, SwrveConfig> {
     void processIntent(Intent intent);
 
     void onTokenRefreshed();
+    
+    String getRegistrationId() ;
 }

--- a/SwrveSDK/src/google/java/com/swrve/sdk/SwrveEmpty.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/SwrveEmpty.java
@@ -34,4 +34,9 @@ public class SwrveEmpty extends SwrveBaseEmpty<ISwrve, SwrveConfig> implements I
     @Override
     public void processIntent(Intent intent) {
     }
+    
+    @Override
+    public String getRegistrationId() {
+        return "";
+    }
 }

--- a/SwrveSDK/src/google/java/com/swrve/sdk/SwrveSDK.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/SwrveSDK.java
@@ -43,6 +43,17 @@ public class SwrveSDK extends SwrveSDKBase {
         }
         return (ISwrve) instance;
     }
+    
+    /**
+     * Gets the current registration ID for application on GCM service.
+     * If result is empty, the app needs to register.
+     *
+     * @return registration ID, or empty string if there is no existing
+     * registration ID.
+     */
+    public static String getRegistrationId() {
+        return ((ISwrve) instance).getRegistrationId();
+    }
 
     /**
      * Returns the Swrve configuration that was used to initialize the SDK.


### PR DESCRIPTION
getRegistrationId was present but to accessible from SwrveSDK. the access to this function is often required in order to work with the deviceToken for push notifications (e.g. by third party services).
