### PR TITLE
add message lifecycle listener

### DIFF
--- a/SwrveSDK/src/main/java/com/swrve/sdk/ISwrveBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/ISwrveBase.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import com.swrve.sdk.config.SwrveConfigBase;
 import com.swrve.sdk.messaging.ISwrveCustomButtonListener;
 import com.swrve.sdk.messaging.ISwrveDialogListener;
+import com.swrve.sdk.messaging.ISwrveMessageLifecycleListener;
 import com.swrve.sdk.messaging.SwrveBaseCampaign;
 import com.swrve.sdk.messaging.ISwrveInstallButtonListener;
 import com.swrve.sdk.messaging.ISwrveMessageListener;
@@ -112,6 +113,8 @@ public interface ISwrveBase<T, C extends SwrveConfigBase> {
     ISwrveDialogListener getDialogListener();
 
     void setDialogListener(ISwrveDialogListener dialogListener);
+
+    void setMessageLifecycleListener(ISwrveMessageLifecycleListener messageLifecycleListener);
 
     Context getContext();
 

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
@@ -23,6 +23,7 @@ import com.swrve.sdk.localstorage.SQLiteLocalStorage;
 import com.swrve.sdk.messaging.ISwrveCustomButtonListener;
 import com.swrve.sdk.messaging.ISwrveDialogListener;
 import com.swrve.sdk.messaging.ISwrveInstallButtonListener;
+import com.swrve.sdk.messaging.ISwrveMessageLifecycleListener;
 import com.swrve.sdk.messaging.ISwrveMessageListener;
 import com.swrve.sdk.messaging.SwrveActionType;
 import com.swrve.sdk.messaging.SwrveBaseCampaign;
@@ -183,6 +184,7 @@ public abstract class SwrveBase<T, C extends SwrveConfigBase> extends SwrveImp<T
                                     SwrveLogger.e(LOG_TAG, "Can't display a message with a non-Activity context");
                                     return;
                                 }
+
                                 // Run code on the UI thread
                                 activity.runOnUiThread(new DisplayMessageRunnable(SwrveBase.this, activity, message, firstTime));
                             }
@@ -1141,6 +1143,10 @@ public abstract class SwrveBase<T, C extends SwrveConfigBase> extends SwrveImp<T
         this.dialogListener = dialogListener;
     }
 
+    protected void _setMessageLifecycleListener(ISwrveMessageLifecycleListener messageLifecycleListener) {
+        this.messageLifecycleListener = messageLifecycleListener;
+    }
+
     protected ISwrveDialogListener _getDialogListener() {
         return dialogListener;
     }
@@ -1589,6 +1595,15 @@ public abstract class SwrveBase<T, C extends SwrveConfigBase> extends SwrveImp<T
     public void setDialogListener(ISwrveDialogListener dialogListener) {
         try {
             _setDialogListener(dialogListener);
+        } catch (Exception e) {
+            SwrveLogger.e(LOG_TAG, "Exception thrown in Swrve SDK", e);
+        }
+    }
+
+    @Override
+    public void setMessageLifecycleListener(ISwrveMessageLifecycleListener messageLifecycleListener) {
+        try {
+            _setMessageLifecycleListener(messageLifecycleListener);
         } catch (Exception e) {
             SwrveLogger.e(LOG_TAG, "Exception thrown in Swrve SDK", e);
         }

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBaseEmpty.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBaseEmpty.java
@@ -8,6 +8,7 @@ import com.swrve.sdk.config.SwrveConfigBase;
 import com.swrve.sdk.messaging.ISwrveCustomButtonListener;
 import com.swrve.sdk.messaging.ISwrveDialogListener;
 import com.swrve.sdk.messaging.ISwrveInstallButtonListener;
+import com.swrve.sdk.messaging.ISwrveMessageLifecycleListener;
 import com.swrve.sdk.messaging.ISwrveMessageListener;
 import com.swrve.sdk.messaging.SwrveBaseCampaign;
 import com.swrve.sdk.messaging.SwrveButton;
@@ -39,6 +40,7 @@ public class SwrveBaseEmpty<T, C extends SwrveConfigBase> implements ISwrveBase<
     private ISwrveCustomButtonListener customButtonListener;
     private ISwrveInstallButtonListener installButtonListener;
     private ISwrveDialogListener dialogListener;
+    private ISwrveMessageLifecycleListener messageLifecycleListener;
     private String language = "en-US";
     private String userId;
     private File cacheDir;
@@ -283,6 +285,11 @@ public class SwrveBaseEmpty<T, C extends SwrveConfigBase> implements ISwrveBase<
     @Override
     public void setDialogListener(ISwrveDialogListener dialogListener) {
         this.dialogListener = dialogListener;
+    }
+
+    @Override
+    public void setMessageLifecycleListener(ISwrveMessageLifecycleListener messageLifecycleListener) {
+        this.messageLifecycleListener = messageLifecycleListener;
     }
 
     @Override

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveImp.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveImp.java
@@ -30,6 +30,7 @@ import com.swrve.sdk.localstorage.SQLiteLocalStorage;
 import com.swrve.sdk.messaging.ISwrveCustomButtonListener;
 import com.swrve.sdk.messaging.ISwrveDialogListener;
 import com.swrve.sdk.messaging.ISwrveInstallButtonListener;
+import com.swrve.sdk.messaging.ISwrveMessageLifecycleListener;
 import com.swrve.sdk.messaging.ISwrveMessageListener;
 import com.swrve.sdk.messaging.SwrveBaseCampaign;
 import com.swrve.sdk.messaging.SwrveCampaign;
@@ -156,6 +157,7 @@ abstract class SwrveImp<T, C extends SwrveConfigBase> {
     protected ISwrveCustomButtonListener customButtonListener;
     protected ISwrveDialogListener dialogListener;
     protected ISwrveResourcesListener resourcesListener;
+    protected ISwrveMessageLifecycleListener messageLifecycleListener;
     protected ExecutorService autoShowExecutor;
     protected String userInstallTime;
     protected AtomicInteger bindCounter;
@@ -1427,9 +1429,17 @@ abstract class SwrveImp<T, C extends SwrveConfigBase> {
                                     currentDialog = null;
                                 }
                             }
+                            if (messageLifecycleListener != null) {
+                                messageLifecycleListener.onDismissMessage(message);
+                            }
+
                         }
                     });
                     saveCurrentOrientation(activity);
+
+                    if (messageLifecycleListener != null) {
+                        messageLifecycleListener.onShowMessage(message);
+                    }
 
                     // Check if the customer wants to manage the dialog themselves
                     if (dialogListener != null) {

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveSDKBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveSDKBase.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import com.swrve.sdk.messaging.ISwrveCustomButtonListener;
 import com.swrve.sdk.messaging.ISwrveDialogListener;
 import com.swrve.sdk.messaging.ISwrveInstallButtonListener;
+import com.swrve.sdk.messaging.ISwrveMessageLifecycleListener;
 import com.swrve.sdk.messaging.ISwrveMessageListener;
 import com.swrve.sdk.messaging.SwrveBaseCampaign;
 import com.swrve.sdk.messaging.SwrveButton;
@@ -501,6 +502,16 @@ public abstract class SwrveSDKBase {
     public static void setDialogListener(ISwrveDialogListener dialogListener) {
         checkInstanceCreated();
         instance.setDialogListener(dialogListener);
+    }
+
+    /**
+     * Set a listener for in-app message lifecycle events.
+     *
+     * @param messageLifecycleListener
+     */
+    public static void setMessageLifecycleListener(ISwrveMessageLifecycleListener messageLifecycleListener) {
+        checkInstanceCreated();
+        instance.setMessageLifecycleListener(messageLifecycleListener);
     }
 
     /**

--- a/SwrveSDK/src/main/java/com/swrve/sdk/messaging/ISwrveMessageLifecycleListener.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/messaging/ISwrveMessageLifecycleListener.java
@@ -1,0 +1,19 @@
+package com.swrve.sdk.messaging;
+
+/**
+ * Implement this interface to listen for in-app message lifecycle events.
+ */
+public interface ISwrveMessageLifecycleListener {
+
+    /**
+     * Invoked when an in-app message dialog is shown.
+     * @param message The message being shown
+     */
+    void onShowMessage(SwrveMessage message);
+
+    /**
+     * Invoked when an in-app message dialog is dismissed.
+     * @param message The dismissed message
+     */
+    void onDismissMessage(SwrveMessage message);
+}


### PR DESCRIPTION
We needed to add a lifecycle listener to enable pausing/resuming games when in-app message dialogs are shown/dismissed.
