### PR TITLE
Add proguard rules to avoid obfuscating of model classes

### DIFF
--- a/SwrveSDKCommon/proguard-rules.pro
+++ b/SwrveSDKCommon/proguard-rules.pro
@@ -15,3 +15,11 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+# Do not obfuscate fields of model classes to be parsed by GSON
+-keepclassmembernames public class com.swrve.sdk.messaging.model.** {
+   <fields>;
+}
+-keepclassmembernames public class com.swrve.sdk.conversations.engine.model.** {
+   <fields>;
+}


### PR DESCRIPTION
If client app uses proguard with agressive rules and obfuscating, all fields in model classes are obfuscated as well. Because of this GSON cannot parse them. That can causes issues in different places, e.g. In-Apps are not working, because `Trigger` entity is not parsed. And other cases

The pull request adds needed proguard rules. But you guys have to verify if the proguard file is added
to .aar file before uploading to public repository (usually it should)
