### PR TITLE
13060 Ability to manually set the GCM registration ID

### DIFF
--- a/SwrveSDK/src/google/java/com/swrve/sdk/ISwrve.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/ISwrve.java
@@ -18,5 +18,7 @@ public interface ISwrve extends ISwrveBase<ISwrve, SwrveConfig> {
 
     void processIntent(Intent intent);
 
+    void setRegistrationId(String registrationId);
+
     void onTokenRefreshed();
 }

--- a/SwrveSDK/src/google/java/com/swrve/sdk/SwrveEmpty.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/SwrveEmpty.java
@@ -34,4 +34,8 @@ public class SwrveEmpty extends SwrveBaseEmpty<ISwrve, SwrveConfig> implements I
     @Override
     public void processIntent(Intent intent) {
     }
+
+    @Override
+    public void setRegistrationId(String regId) {
+    }
 }

--- a/SwrveSDK/src/google/java/com/swrve/sdk/config/SwrveConfig.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/config/SwrveConfig.java
@@ -13,6 +13,11 @@ public class SwrveConfig extends SwrveConfigBase {
     private String senderId;
 
     /**
+     * Automatically get the Google Cloud Messaging Registration ID.
+     */
+    private boolean obtainRegistrationIdEnabled = true;
+
+    /**
      * Automatically log Google's Advertising Id as "swrve.GAID".
      */
     private boolean gAIDLoggingEnabled;
@@ -35,7 +40,7 @@ public class SwrveConfig extends SwrveConfigBase {
     }
 
     /**
-     * @param senderId the Google Cloud Messaging sender id to set
+     * @param senderId the Google Cloud Messaging Sender ID for your app.
      */
     public SwrveConfig setSenderId(String senderId) {
         this.senderId = senderId;
@@ -61,5 +66,19 @@ public class SwrveConfig extends SwrveConfigBase {
      */
     public void setGAIDLoggingEnabled(boolean enabled) {
         this.gAIDLoggingEnabled = enabled;
+    }
+
+    /**
+     * @return if it will automatically obtain the Google Cloud Messaging Registration ID.
+     */
+    public boolean isObtainRegistrationIdEnabled() {
+        return obtainRegistrationIdEnabled;
+    }
+
+    /**
+     * @param enabled to automatically obtain the Google Cloud Messaging Registration ID.
+     */
+    public void setObtainRegistrationIdEnabled(boolean enabled) {
+        this.obtainRegistrationIdEnabled = enabled;
     }
 }

--- a/SwrveSDKTest/src/testGoogle/java/com/swrve/sdk/SwrveGoogleUnitTest.java
+++ b/SwrveSDKTest/src/testGoogle/java/com/swrve/sdk/SwrveGoogleUnitTest.java
@@ -78,4 +78,15 @@ public class SwrveGoogleUnitTest {
         assertEquals("customdata_value", nextIntent.getStringExtra("customdata"));
     }
 
+    @Test
+    public void testManualRegistrationId() {
+        SwrveConfig config = new SwrveConfig();
+        config.setSenderId("12345");
+        config.setObtainRegistrationIdEnabled(false);
+        Swrve swrve = (Swrve) SwrveSDK.createInstance(activity, 1, "apiKey", config);
+        swrve.setRegistrationId("manual_reg_id");
+
+        // An event must be sent
+        // TOOD: HTTP mock server check that an update event was sent with the right property
+    }
 }

--- a/SwrveSDKTest/src/testGoogle/java/com/swrve/sdk/test/SwrveGoogleConfigTest.java
+++ b/SwrveSDKTest/src/testGoogle/java/com/swrve/sdk/test/SwrveGoogleConfigTest.java
@@ -41,4 +41,13 @@ public class SwrveGoogleConfigTest {
         swrveConfig.setAndroidIdLoggingEnabled(true);
         assertEquals(true, swrveConfig.isAndroidIdLoggingEnabled());
     }
+
+    @Test
+    public void testObtainRegistrationId() {
+        SwrveConfig swrveConfig = new SwrveConfig();
+        assertEquals(true, swrveConfig.isObtainRegistrationIdEnabled());
+
+        swrveConfig.setAndroidIdLoggingEnabled(false);
+        assertEquals(false, swrveConfig.isObtainRegistrationIdEnabled());
+    }
 }


### PR DESCRIPTION
https://swrvedev.jira.com/browse/SWRVE-13060

NOTE: Must update the tests to use our http test server and assert that the right user property was sent  once the setter was called.
