### PR TITLE
12991_star_rating_touch_accuracy

### DIFF
--- a/SwrveConversationSDK/src/main/java/com/swrve/sdk/conversations/ui/ConversationRatingBar.java
+++ b/SwrveConversationSDK/src/main/java/com/swrve/sdk/conversations/ui/ConversationRatingBar.java
@@ -55,7 +55,7 @@ public class ConversationRatingBar extends LinearLayout implements RatingBar.OnR
     private void initRatingBar() {
         ratingBar = new RatingBar(getContext(), null, R.attr.conversationContentRatingBarStyle);
         ratingBar.setNumStars(5);
-        ratingBar.setStepSize(1.0f);
+        ratingBar.setStepSize(0.01f); // set a tiny increment and do the rounding in onRatingChanged method.
         ratingBar.setOnRatingBarChangeListener(this);
 
         LayoutParams layoutParams = new LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -93,8 +93,19 @@ public class ConversationRatingBar extends LinearLayout implements RatingBar.OnR
 
     @Override
     public void onRatingChanged(RatingBar ratingBar, float rating, boolean fromUser) {
+        if(!fromUser) {
+            return;
+        }
         if (rating < 1.0f) { // Once a star value is selected it can never be set to less than one
             ratingBar.setRating(1.0f);
+        } else if (rating > 1.0f && rating <= 2.0f) {
+            ratingBar.setRating(2.0f);
+        } else if (rating > 2.0f && rating <= 3.0f) {
+            ratingBar.setRating(3.0f);
+        } else if (rating > 3.0f && rating <= 4.0f) {
+            ratingBar.setRating(4.0f);
+        } else if (rating > 4.0f && rating <= 5.0f) {
+            ratingBar.setRating(5.0f);
         }
 
         if (inputChangedListener != null) {

--- a/SwrveConversationSDK/src/main/java/com/swrve/sdk/conversations/ui/ConversationRatingBar.java
+++ b/SwrveConversationSDK/src/main/java/com/swrve/sdk/conversations/ui/ConversationRatingBar.java
@@ -98,14 +98,9 @@ public class ConversationRatingBar extends LinearLayout implements RatingBar.OnR
         }
         if (rating < 1.0f) { // Once a star value is selected it can never be set to less than one
             ratingBar.setRating(1.0f);
-        } else if (rating > 1.0f && rating <= 2.0f) {
-            ratingBar.setRating(2.0f);
-        } else if (rating > 2.0f && rating <= 3.0f) {
-            ratingBar.setRating(3.0f);
-        } else if (rating > 3.0f && rating <= 4.0f) {
-            ratingBar.setRating(4.0f);
-        } else if (rating > 4.0f && rating <= 5.0f) {
-            ratingBar.setRating(5.0f);
+        } else {
+            float rounded = (float) Math.ceil(rating);
+            ratingBar.setRating(rounded);
         }
 
         if (inputChangedListener != null) {

--- a/SwrveSDKTest/src/test/java/com/swrve/sdk/ConversationFragmentTest.java
+++ b/SwrveSDKTest/src/test/java/com/swrve/sdk/ConversationFragmentTest.java
@@ -254,7 +254,7 @@ public class ConversationFragmentTest extends SwrveBaseTest{
         assertThat(conversationRatingBar.getModel().getStarColor(), equalTo("#ff0000"));
         assertThat(conversationRatingBar.getModel().getValue(), equalTo("value0"));
         assertThat(conversationRatingBar.getRatingBar().getNumStars(), equalTo(5));
-        assertThat(conversationRatingBar.getRatingBar().getStepSize(), equalTo(1.0f));
+        assertThat(conversationRatingBar.getRatingBar().getStepSize(), equalTo(0.01f));
 
         // test less than zero selected but value only goes to 1.0
         conversationRatingBar.onRatingChanged(conversationRatingBar.getRatingBar(), 0.5f, true);
@@ -274,7 +274,7 @@ public class ConversationFragmentTest extends SwrveBaseTest{
         assertThat(conversationRatingBar.getModel().getStarColor(), equalTo("#ff0000"));
         assertThat(conversationRatingBar.getModel().getValue(), equalTo("value0"));
         assertThat(conversationRatingBar.getRatingBar().getNumStars(), equalTo(5));
-        assertThat(conversationRatingBar.getRatingBar().getStepSize(), equalTo(1.0f));
+        assertThat(conversationRatingBar.getRatingBar().getStepSize(), equalTo(0.01f));
 
         // test less than zero selected but value only goes to 1.0
         conversationRatingBar.onRatingChanged(conversationRatingBar.getRatingBar(), 0.5f, true);


### PR DESCRIPTION
https://swrvedev.jira.com/browse/SWRVE-12991
Fixed issue with some devices selecting more stars than was touched. (Samsung s6 for example). Tapping the right side of star filled in the color of the star to the star. Fixed this by using small stepsize increments and doing the rounding ourselves.

@Sergio-Mira please
