### PR TITLE
13426-missing_seqnum

### DIFF
--- a/SwrveSDK/src/google/java/com/swrve/sdk/SwrvePushEngageReceiver.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/SwrvePushEngageReceiver.java
@@ -68,7 +68,7 @@ public class SwrvePushEngageReceiver extends BroadcastReceiver {
             ArrayList<String> events = new ArrayList<>();
             Map<String, Object> parameters = new HashMap<>();
             parameters.put("name", name);
-            eventString = EventHelper.eventAsJSON("event", parameters, null, null);
+            eventString = EventHelper.eventAsJSON("event", parameters, swrve.getNextSequenceNumber());
             events.add(eventString);
             swrve.sendEventsWakefully(context, events);
         } catch (JSONException e) {

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
@@ -5,12 +5,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.net.Uri;
 import android.os.Build;
-import android.os.Bundle;
-import android.os.Handler;
-import android.os.Message;
-import android.os.Messenger;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.SparseArray;
@@ -31,9 +26,9 @@ import com.swrve.sdk.messaging.ISwrveMessageListener;
 import com.swrve.sdk.messaging.SwrveActionType;
 import com.swrve.sdk.messaging.SwrveBaseCampaign;
 import com.swrve.sdk.messaging.SwrveButton;
-import com.swrve.sdk.messaging.SwrveInAppCampaign;
 import com.swrve.sdk.messaging.SwrveCampaignState;
 import com.swrve.sdk.messaging.SwrveConversationCampaign;
+import com.swrve.sdk.messaging.SwrveInAppCampaign;
 import com.swrve.sdk.messaging.SwrveMessage;
 import com.swrve.sdk.messaging.SwrveMessageFormat;
 import com.swrve.sdk.messaging.SwrveOrientation;
@@ -1664,6 +1659,17 @@ public abstract class SwrveBase<T, C extends SwrveConfigBase> extends SwrveImp<T
     @Override
     public int getMaxEventsPerFlush() {
         return config.getMaxEventsPerFlush();
+    }
+
+    @Override
+    public synchronized int getNextSequenceNumber() {
+        String id = cachedLocalStorage.getSharedCacheEntry("seqnum");
+        int seqnum = 1;
+        if (!SwrveHelper.isNullOrEmpty(id)) {
+            seqnum = Integer.parseInt(id) + 1;
+        }
+        cachedLocalStorage.setAndFlushSharedEntry("seqnum", Integer.toString(seqnum));
+        return seqnum;
     }
 
     /***

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveCampaignDisplayer.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveCampaignDisplayer.java
@@ -126,7 +126,7 @@ public class SwrveCampaignDisplayer {
 
     protected boolean canTrigger(SwrveBaseCampaign swrveCampaign, String eventName, Map<String, String> payload, Map<Integer, Result> campaignDisplayResults) {
         if (swrveCampaign.getTriggers() == null || swrveCampaign.getTriggers().size() == 0) {
-            String resultText = "Campaign [" + swrveCampaign.getId() + "], invalid triggers. Skipping this campaign.";
+            String resultText = "Campaign [" + swrveCampaign.getId() + "], no triggers (could be message centre). Skipping this campaign.";
             logAndAddReason(swrveCampaign, campaignDisplayResults, DisplayResult.ERROR_INVALID_TRIGGERS, resultText);
             return false;
         }

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveImp.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveImp.java
@@ -3,15 +3,11 @@ package com.swrve.sdk;
 import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.content.BroadcastReceiver;
 import android.content.Context;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
-import android.net.Uri;
 import android.os.Build;
-import android.os.Bundle;
 import android.provider.Settings;
 import android.support.v4.app.ActivityCompat;
 import android.util.DisplayMetrics;
@@ -32,12 +28,10 @@ import com.swrve.sdk.messaging.ISwrveCustomButtonListener;
 import com.swrve.sdk.messaging.ISwrveInstallButtonListener;
 import com.swrve.sdk.messaging.ISwrveMessageListener;
 import com.swrve.sdk.messaging.SwrveBaseCampaign;
-import com.swrve.sdk.messaging.SwrveButton;
-import com.swrve.sdk.messaging.SwrveInAppCampaign;
 import com.swrve.sdk.messaging.SwrveCampaignState;
 import com.swrve.sdk.messaging.SwrveConversationCampaign;
+import com.swrve.sdk.messaging.SwrveInAppCampaign;
 import com.swrve.sdk.messaging.SwrveMessage;
-import com.swrve.sdk.messaging.SwrveMessageFormat;
 import com.swrve.sdk.messaging.SwrveOrientation;
 import com.swrve.sdk.qa.SwrveQAUser;
 import com.swrve.sdk.rest.IRESTClient;
@@ -1269,6 +1263,7 @@ abstract class SwrveImp<T, C extends SwrveConfigBase> implements ISwrveCampaignM
         }
     }
 
+    @Deprecated
     public String getAutoShowEventTrigger() {
         return SWRVE_AUTOSHOW_AT_SESSION_START_TRIGGER;
     }
@@ -1287,16 +1282,18 @@ abstract class SwrveImp<T, C extends SwrveConfigBase> implements ISwrveCampaignM
         @Override
         public void run() {
             try {
-                String eventString = EventHelper.eventAsJSON(eventType, parameters, payload, cachedLocalStorage);
+                int seqNum = getNextSequenceNumber();
+                String eventString = EventHelper.eventAsJSON(eventType, parameters, payload, seqNum);
                 parameters = null;
                 payload = null;
                 cachedLocalStorage.addEvent(eventString);
                 SwrveLogger.i(LOG_TAG, eventType + " event queued");
-            } catch (JSONException je) {
-                SwrveLogger.e(LOG_TAG, "Parameter or payload data not encodable as JSON", je);
-            } catch (Exception se) {
-                SwrveLogger.e(LOG_TAG, "Unable to insert into local storage", se);
+            } catch (Exception e) {
+                SwrveLogger.e(LOG_TAG, "Unable to insert QueueEvent into local storage.", e);
             }
         }
     }
+
+    abstract int getNextSequenceNumber();
+
 }

--- a/SwrveSDKCommon/src/main/java/com/swrve/sdk/EventHelper.java
+++ b/SwrveSDKCommon/src/main/java/com/swrve/sdk/EventHelper.java
@@ -27,27 +27,20 @@ final class EventHelper {
         }
     }
 
-    private synchronized static int getNextSequenceNumber(IMemoryLocalStorage storage) {
-        String id = storage.getSharedCacheEntry("seqnum");
-        int seqnum = 1;
-        if (!SwrveHelper.isNullOrEmpty(id)) {
-            seqnum = Integer.parseInt(id) + 1;
-        }
-        storage.setAndFlushSharedEntry("seqnum", Integer.toString(seqnum));
-        return seqnum;
+    public static String eventAsJSON(String type, Map<String, Object> parameters, int seqnum) throws JSONException {
+        return eventAsJSON(type, parameters, null, seqnum);
     }
 
     /*
      * Generate JSON to be stored in EventLocalStorage and eventually sent to
      * the batch API to inform Swrve of these events.
      */
-    public static String eventAsJSON(String type, Map<String, Object> parameters,
-                                     Map<String, String> payload, IMemoryLocalStorage storage) throws JSONException {
+    public static String eventAsJSON(String type, Map<String, Object> parameters, Map<String, String> payload, int seqnum) throws JSONException {
         JSONObject obj = new JSONObject();
         obj.put("type", type);
         obj.put("time", System.currentTimeMillis());
-        if (storage != null) {
-            obj.put("seqnum", getNextSequenceNumber(storage));
+        if (seqnum > 0) {
+            obj.put("seqnum", seqnum);
         }
         if (parameters != null) {
             for (Map.Entry<String, Object> entry : parameters.entrySet()) {

--- a/SwrveSDKCommon/src/main/java/com/swrve/sdk/ISwrveCommon.java
+++ b/SwrveSDKCommon/src/main/java/com/swrve/sdk/ISwrveCommon.java
@@ -70,4 +70,6 @@ interface ISwrveCommon
 
     JSONObject getDeviceInfo() throws JSONException;
 
+    int getNextSequenceNumber();
+
 }


### PR DESCRIPTION
New method getNextSequenceNumber added to ISwrveCommon.
The seqnum is now passed into EventHelper.eventAsJSON, which means other services (such as location and push) can now create valid event json.

https://swrvedev.jira.com/browse/SWRVE-13426

Also deprecated a unused method in SwrveImp. Couldn't see why it is exposed. 

@seaders @Sergio-Mira @adam-govan 
