### PR TITLE
14628 - using single lock for event storage read/write

### DIFF
--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
@@ -114,8 +114,6 @@ public abstract class SwrveBase<T, C extends SwrveConfigBase> extends SwrveImp<T
             this.sessionToken = SwrveHelper.generateSessionToken(this.apiKey, this.appId, userId); // Generate session token
 
             cachedLocalStorage = createCachedLocalStorage();
-            short deviceId = EventHelper.getDeviceId(cachedLocalStorage);
-            swrveEventsManager = new SwrveEventsManagerImp(config, restClient, userId, appVersion, sessionToken, deviceId);
 
             appStoreURLs = new SparseArray<String>();
 
@@ -417,6 +415,8 @@ public abstract class SwrveBase<T, C extends SwrveConfigBase> extends SwrveImp<T
             restClientExecutorExecute(new Runnable() {
                 @Override
                 public void run() {
+                    short deviceId = EventHelper.getDeviceId(cachedLocalStorage);
+                    SwrveEventsManager swrveEventsManager = new SwrveEventsManagerImp(config, restClient, userId, appVersion, sessionToken, deviceId);
                     swrveEventsManager.sendStoredEvents(cachedLocalStorage);
                     eventsWereSent = true;
                 }

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
@@ -114,6 +114,8 @@ public abstract class SwrveBase<T, C extends SwrveConfigBase> extends SwrveImp<T
             this.sessionToken = SwrveHelper.generateSessionToken(this.apiKey, this.appId, userId); // Generate session token
 
             cachedLocalStorage = createCachedLocalStorage();
+            short deviceId = EventHelper.getDeviceId(cachedLocalStorage);
+            swrveEventsManager = new SwrveEventsManagerImp(config, restClient, userId, appVersion, sessionToken, deviceId);
 
             appStoreURLs = new SparseArray<String>();
 
@@ -415,8 +417,6 @@ public abstract class SwrveBase<T, C extends SwrveConfigBase> extends SwrveImp<T
             restClientExecutorExecute(new Runnable() {
                 @Override
                 public void run() {
-                    short deviceId = EventHelper.getDeviceId(cachedLocalStorage);
-                    SwrveEventsManager swrveEventsManager = new SwrveEventsManager(config, restClient, userId, appVersion, sessionToken, deviceId);
                     swrveEventsManager.sendStoredEvents(cachedLocalStorage);
                     eventsWereSent = true;
                 }

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveEventsManager.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveEventsManager.java
@@ -1,133 +1,16 @@
 package com.swrve.sdk;
 
-import com.swrve.sdk.config.SwrveConfigBase;
-import com.swrve.sdk.localstorage.ILocalStorage;
 import com.swrve.sdk.localstorage.MemoryCachedLocalStorage;
 import com.swrve.sdk.localstorage.SQLiteLocalStorage;
-import com.swrve.sdk.rest.IRESTClient;
-import com.swrve.sdk.rest.IRESTResponseListener;
-import com.swrve.sdk.rest.RESTResponse;
-
-import org.json.JSONException;
 
 import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
 
-public class SwrveEventsManager {
+/**
+ * Used internally to send events.
+ */
+interface SwrveEventsManager {
 
-    private static final String LOG_TAG = "SwrveSDK";
+    int storeAndSendEvents(ArrayList<String> eventsJson, MemoryCachedLocalStorage memoryCachedLocalStorage, SQLiteLocalStorage sqLiteLocalStorage) throws Exception;
 
-    private final SwrveConfigBase config;
-    private final IRESTClient restClient;
-    private final String userId;
-    private final String appVersion;
-    private final String sessionToken;
-    private final short deviceId;
-
-    protected SwrveEventsManager(SwrveConfigBase config, IRESTClient restClient, String userId, String appVersion, String sessionToken, short deviceId) {
-        this.config = config;
-        this.restClient = restClient;
-        this.userId = userId;
-        this.appVersion = appVersion;
-        this.sessionToken = sessionToken;
-        this.deviceId = deviceId;
-    }
-
-    /*
-     * Stores the events passed in from ArrayList and attempts to send only these events. If successful, these events are removed from storage.
-     */
-    protected int storeAndSendEvents(ArrayList<String> eventsJson, MemoryCachedLocalStorage memoryCachedLocalStorage, SQLiteLocalStorage sqLiteLocalStorage) throws Exception {
-        if (eventsJson == null || (eventsJson != null && eventsJson.size() == 0)) {
-            return 0;
-        }
-        synchronized(MemoryCachedLocalStorage.EVENT_LOCK) {
-            LinkedHashMap<Long, String> storedEvents = storeEvents(eventsJson, sqLiteLocalStorage);
-            LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>> combinedEvents = new LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>>();
-            combinedEvents.put(memoryCachedLocalStorage, storedEvents);
-            return sendEvents(combinedEvents);
-        }
-    }
-
-    private LinkedHashMap<Long, String> storeEvents(ArrayList<String> eventsJson, SQLiteLocalStorage sqLiteLocalStorage) throws Exception {
-        LinkedHashMap<Long, String> storedEvents = new LinkedHashMap<Long, String>();
-        // Store named events coming from the list
-        for (String eventAsJSON : eventsJson) {
-            long id = sqLiteLocalStorage.addEventAndGetId(eventAsJSON);
-            storedEvents.put(id, eventAsJSON);
-        }
-
-        return storedEvents;
-    }
-
-    /*
-     * Attempts to sends events from local storage and deletes them if successful. Number of events sent configured from config.
-     */
-    protected int sendStoredEvents(MemoryCachedLocalStorage cachedLocalStorage) {
-        synchronized(MemoryCachedLocalStorage.EVENT_LOCK) {
-            final LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>> combinedEvents = cachedLocalStorage.getCombinedFirstNEvents(config.getMaxEventsPerFlush());
-            return sendEvents(combinedEvents);
-        }
-    }
-
-    private int sendEvents(final LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>> combinedEvents) {
-        int eventsSent = 0;
-        final LinkedHashMap<Long, String> events = new LinkedHashMap<Long, String>();
-        if (!combinedEvents.isEmpty()) {
-            SwrveLogger.i(LOG_TAG, "Sending queued events");
-            try {
-                // Combine all events
-                Iterator<ILocalStorage> storageIt = combinedEvents.keySet().iterator();
-                while (storageIt.hasNext()) {
-                    events.putAll(combinedEvents.get(storageIt.next()));
-                }
-                eventsSent = events.size();
-                String data = EventHelper.eventsAsBatch(events, userId, appVersion, sessionToken, deviceId);
-                SwrveLogger.i(LOG_TAG, "Sending " + events.size() + " events to Swrve");
-                postBatchRequest(data, new IPostBatchRequestListener() {
-                    public void onResponse(boolean shouldDelete) {
-                        if (shouldDelete) {
-                            // Remove events from where they came from
-                            Iterator<ILocalStorage> storageIt = combinedEvents.keySet().iterator();
-                            while (storageIt.hasNext()) {
-                                ILocalStorage storage = storageIt.next();
-                                storage.removeEventsById(combinedEvents.get(storage).keySet());
-                            }
-                        } else {
-                            SwrveLogger.e(LOG_TAG, "Batch of events could not be sent, retrying");
-                        }
-                    }
-                });
-            } catch (JSONException je) {
-                SwrveLogger.e(LOG_TAG, "Unable to generate event batch, and send events", je);
-            }
-        }
-        return eventsSent;
-    }
-
-    private void postBatchRequest(final String postData, final IPostBatchRequestListener listener) {
-
-        restClient.post(config.getEventsUrl() + SwrveBase.BATCH_EVENTS_ACTION, postData, new IRESTResponseListener() {
-            @Override
-            public void onResponse(RESTResponse response) {
-                boolean deleteEvents = true;
-                if (SwrveHelper.userErrorResponseCode(response.responseCode)) {
-                    SwrveLogger.e(LOG_TAG, "Error sending events to Swrve: " + response.responseBody);
-                } else if (SwrveHelper.successResponseCode(response.responseCode)) {
-                    SwrveLogger.i(LOG_TAG, "Events sent to Swrve");
-                } else if (SwrveHelper.serverErrorResponseCode(response.responseCode)) {
-                    deleteEvents = false;
-                    SwrveLogger.e(LOG_TAG, "Error sending events to Swrve: " + response.responseBody);
-                }
-
-                // Resend if we got a server error (5XX)
-                listener.onResponse(deleteEvents);
-            }
-
-            @Override
-            public void onException(Exception ex) {
-                SwrveLogger.e(LOG_TAG, "Error posting batch of events. postData:" + postData, ex);
-            }
-        });
-    }
+    int sendStoredEvents(MemoryCachedLocalStorage cachedLocalStorage);
 }

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveEventsManager.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveEventsManager.java
@@ -11,15 +11,12 @@ import com.swrve.sdk.rest.RESTResponse;
 import org.json.JSONException;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.Map;
 
 public class SwrveEventsManager {
 
     private static final String LOG_TAG = "SwrveSDK";
-    private static final Object lock = new Object();
 
     private final SwrveConfigBase config;
     private final IRESTClient restClient;
@@ -44,7 +41,7 @@ public class SwrveEventsManager {
         if (eventsJson == null || (eventsJson != null && eventsJson.size() == 0)) {
             return 0;
         }
-        synchronized(lock) {
+        synchronized(MemoryCachedLocalStorage.EVENT_LOCK) {
             LinkedHashMap<Long, String> storedEvents = storeEvents(eventsJson, sqLiteLocalStorage);
             LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>> combinedEvents = new LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>>();
             combinedEvents.put(memoryCachedLocalStorage, storedEvents);
@@ -67,7 +64,7 @@ public class SwrveEventsManager {
      * Attempts to sends events from local storage and deletes them if successful. Number of events sent configured from config.
      */
     protected int sendStoredEvents(MemoryCachedLocalStorage cachedLocalStorage) {
-        synchronized(lock) {
+        synchronized(MemoryCachedLocalStorage.EVENT_LOCK) {
             final LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>> combinedEvents = cachedLocalStorage.getCombinedFirstNEvents(config.getMaxEventsPerFlush());
             return sendEvents(combinedEvents);
         }

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveEventsManagerImp.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveEventsManagerImp.java
@@ -1,0 +1,135 @@
+package com.swrve.sdk;
+
+import com.swrve.sdk.config.SwrveConfigBase;
+import com.swrve.sdk.localstorage.ILocalStorage;
+import com.swrve.sdk.localstorage.MemoryCachedLocalStorage;
+import com.swrve.sdk.localstorage.SQLiteLocalStorage;
+import com.swrve.sdk.rest.IRESTClient;
+import com.swrve.sdk.rest.IRESTResponseListener;
+import com.swrve.sdk.rest.RESTResponse;
+
+import org.json.JSONException;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+
+public class SwrveEventsManagerImp implements SwrveEventsManager {
+
+    private static final String LOG_TAG = "SwrveSDK";
+
+    private final SwrveConfigBase config;
+    private final IRESTClient restClient;
+    private final String userId;
+    private final String appVersion;
+    private final String sessionToken;
+    private final short deviceId;
+
+    protected SwrveEventsManagerImp(SwrveConfigBase config, IRESTClient restClient, String userId, String appVersion, String sessionToken, short deviceId) {
+        this.config = config;
+        this.restClient = restClient;
+        this.userId = userId;
+        this.appVersion = appVersion;
+        this.sessionToken = sessionToken;
+        this.deviceId = deviceId;
+    }
+
+    /*
+     * Stores the events passed in from ArrayList and attempts to send only these events. If successful, these events are removed from storage.
+     */
+    @Override
+    public int storeAndSendEvents(ArrayList<String> eventsJson, MemoryCachedLocalStorage memoryCachedLocalStorage, SQLiteLocalStorage sqLiteLocalStorage) throws Exception {
+        if (eventsJson == null || (eventsJson != null && eventsJson.size() == 0)) {
+            return 0;
+        }
+        synchronized(MemoryCachedLocalStorage.EVENT_LOCK) {
+            LinkedHashMap<Long, String> storedEvents = storeEvents(eventsJson, sqLiteLocalStorage);
+            LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>> combinedEvents = new LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>>();
+            combinedEvents.put(memoryCachedLocalStorage, storedEvents);
+            return sendEvents(combinedEvents);
+        }
+    }
+
+    private LinkedHashMap<Long, String> storeEvents(ArrayList<String> eventsJson, SQLiteLocalStorage sqLiteLocalStorage) throws Exception {
+        LinkedHashMap<Long, String> storedEvents = new LinkedHashMap<Long, String>();
+        // Store named events coming from the list
+        for (String eventAsJSON : eventsJson) {
+            long id = sqLiteLocalStorage.addEventAndGetId(eventAsJSON);
+            storedEvents.put(id, eventAsJSON);
+        }
+
+        return storedEvents;
+    }
+
+    /*
+     * Attempts to sends events from local storage and deletes them if successful. Number of events sent configured from config.
+     */
+    @Override
+    public int sendStoredEvents(MemoryCachedLocalStorage cachedLocalStorage) {
+        synchronized(MemoryCachedLocalStorage.EVENT_LOCK) {
+            final LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>> combinedEvents = cachedLocalStorage.getCombinedFirstNEvents(config.getMaxEventsPerFlush());
+            return sendEvents(combinedEvents);
+        }
+    }
+
+    private int sendEvents(final LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>> combinedEvents) {
+        int eventsSent = 0;
+        final LinkedHashMap<Long, String> events = new LinkedHashMap<Long, String>();
+        if (!combinedEvents.isEmpty()) {
+            SwrveLogger.i(LOG_TAG, "Sending queued events");
+            try {
+                // Combine all events
+                Iterator<ILocalStorage> storageIt = combinedEvents.keySet().iterator();
+                while (storageIt.hasNext()) {
+                    events.putAll(combinedEvents.get(storageIt.next()));
+                }
+                eventsSent = events.size();
+                String data = EventHelper.eventsAsBatch(events, userId, appVersion, sessionToken, deviceId);
+                SwrveLogger.i(LOG_TAG, "Sending " + events.size() + " events to Swrve");
+                postBatchRequest(data, new IPostBatchRequestListener() {
+                    public void onResponse(boolean shouldDelete) {
+                        if (shouldDelete) {
+                            // Remove events from where they came from
+                            Iterator<ILocalStorage> storageIt = combinedEvents.keySet().iterator();
+                            while (storageIt.hasNext()) {
+                                ILocalStorage storage = storageIt.next();
+                                storage.removeEventsById(combinedEvents.get(storage).keySet());
+                            }
+                        } else {
+                            SwrveLogger.e(LOG_TAG, "Batch of events could not be sent, retrying");
+                        }
+                    }
+                });
+            } catch (JSONException je) {
+                SwrveLogger.e(LOG_TAG, "Unable to generate event batch, and send events", je);
+            }
+        }
+        return eventsSent;
+    }
+
+    private void postBatchRequest(final String postData, final IPostBatchRequestListener listener) {
+
+        restClient.post(config.getEventsUrl() + SwrveBase.BATCH_EVENTS_ACTION, postData, new IRESTResponseListener() {
+            @Override
+            public void onResponse(RESTResponse response) {
+                boolean deleteEvents = true;
+                if (SwrveHelper.userErrorResponseCode(response.responseCode)) {
+                    SwrveLogger.e(LOG_TAG, "Error sending events to Swrve: " + response.responseBody);
+                } else if (SwrveHelper.successResponseCode(response.responseCode)) {
+                    SwrveLogger.i(LOG_TAG, "Events sent to Swrve");
+                } else if (SwrveHelper.serverErrorResponseCode(response.responseCode)) {
+                    deleteEvents = false;
+                    SwrveLogger.e(LOG_TAG, "Error sending events to Swrve: " + response.responseBody);
+                }
+
+                // Resend if we got a server error (5XX)
+                listener.onResponse(deleteEvents);
+            }
+
+            @Override
+            public void onException(Exception ex) {
+                SwrveLogger.e(LOG_TAG, "Error posting batch of events. postData:" + postData, ex);
+            }
+        });
+    }
+}

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveEventsManagerImp.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveEventsManagerImp.java
@@ -114,12 +114,12 @@ public class SwrveEventsManagerImp implements SwrveEventsManager {
             public void onResponse(RESTResponse response) {
                 boolean deleteEvents = true;
                 if (SwrveHelper.userErrorResponseCode(response.responseCode)) {
-                    SwrveLogger.e(LOG_TAG, "Error sending events to Swrve: " + response.responseBody);
+                    SwrveLogger.e(LOG_TAG, "Error sending events to Swrve. responseCode: " + response.responseCode + "\tresponseBody:" + response.responseBody);
                 } else if (SwrveHelper.successResponseCode(response.responseCode)) {
                     SwrveLogger.i(LOG_TAG, "Events sent to Swrve");
                 } else if (SwrveHelper.serverErrorResponseCode(response.responseCode)) {
                     deleteEvents = false;
-                    SwrveLogger.e(LOG_TAG, "Error sending events to Swrve: " + response.responseBody);
+                    SwrveLogger.e(LOG_TAG, "Error sending events to Swrve. Wil retry. responseCode: " + response.responseCode + "\tresponseBody:" + response.responseBody);
                 }
 
                 // Resend if we got a server error (5XX)

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveImp.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveImp.java
@@ -164,6 +164,7 @@ abstract class SwrveImp<T, C extends SwrveConfigBase> implements ISwrveCampaignM
     protected String androidId;
     protected int locationSegmentVersion;
     protected SwrveQAUser qaUser;
+    protected SwrveEventsManager swrveEventsManager;
 
     protected SwrveImp(Context context, int appId, String apiKey, C config) {
         this.appId = appId;

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveImp.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveImp.java
@@ -164,7 +164,6 @@ abstract class SwrveImp<T, C extends SwrveConfigBase> implements ISwrveCampaignM
     protected String androidId;
     protected int locationSegmentVersion;
     protected SwrveQAUser qaUser;
-    protected SwrveEventsManager swrveEventsManager;
 
     protected SwrveImp(Context context, int appId, String apiKey, C config) {
         this.appId = appId;
@@ -1278,7 +1277,7 @@ abstract class SwrveImp<T, C extends SwrveConfigBase> implements ISwrveCampaignM
                 parameters = null;
                 payload = null;
                 cachedLocalStorage.addEvent(eventString);
-                SwrveLogger.i(LOG_TAG, eventType + " event queued");
+                SwrveLogger.i(LOG_TAG, "Event queued of type: " + eventType + " and seqNum:" + seqNum);
             } catch (Exception e) {
                 SwrveLogger.e(LOG_TAG, "Unable to insert QueueEvent into local storage.", e);
             }

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveWakefulService.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveWakefulService.java
@@ -59,6 +59,6 @@ public class SwrveWakefulService extends IntentService {
         IRESTClient restClient = new RESTClient(swrve.config.getHttpTimeout());
         short deviceId = EventHelper.getDeviceId(memoryCachedLocalStorage);
         String sessionToken = SwrveHelper.generateSessionToken(swrve.apiKey, swrve.appId, swrve.userId);
-        return new SwrveEventsManager(swrve.config, restClient, swrve.userId, swrve.appVersion, sessionToken, deviceId);
+        return new SwrveEventsManagerImp(swrve.config, restClient, swrve.userId, swrve.appVersion, sessionToken, deviceId);
     }
 }

--- a/SwrveSDK/src/main/java/com/swrve/sdk/localstorage/MemoryCachedLocalStorage.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/localstorage/MemoryCachedLocalStorage.java
@@ -18,7 +18,8 @@ public class MemoryCachedLocalStorage implements IMemoryLocalStorage {
     private ILocalStorage cache;
     private ILocalStorage secondaryStorage;
 
-    private Object eventLock = new Object();
+    public static final Object EVENT_LOCK = new Object();
+
     private Object cacheLock = new Object();
 
     public MemoryCachedLocalStorage(ILocalStorage cache, ILocalStorage secondaryStorage) {
@@ -85,7 +86,7 @@ public class MemoryCachedLocalStorage implements IMemoryLocalStorage {
     }
 
     public LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>> getCombinedFirstNEvents(Integer n) {
-        synchronized (eventLock) {
+        synchronized (EVENT_LOCK) {
             LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>> result = new LinkedHashMap<ILocalStorage, LinkedHashMap<Long, String>>();
             int eventCount = 0;
             if (secondaryStorage != null) {
@@ -110,21 +111,21 @@ public class MemoryCachedLocalStorage implements IMemoryLocalStorage {
 
     @Override
     public void addEvent(String eventJSON) throws Exception {
-        synchronized (eventLock) {
+        synchronized (EVENT_LOCK) {
             cache.addEvent(eventJSON);
         }
     }
 
     @Override
     public void removeEventsById(Collection<Long> ids) {
-        synchronized (eventLock) {
+        synchronized (EVENT_LOCK) {
             cache.removeEventsById(ids);
         }
     }
 
     @Override
     public LinkedHashMap<Long, String> getFirstNEvents(Integer ids) {
-        synchronized (eventLock) {
+        synchronized (EVENT_LOCK) {
             return cache.getFirstNEvents(ids);
         }
     }
@@ -184,7 +185,7 @@ public class MemoryCachedLocalStorage implements IMemoryLocalStorage {
         if (cache != secondaryStorage && cache instanceof IFlushableLocalStorage && secondaryStorage instanceof IFastInsertLocalStorage) {
             IFlushableLocalStorage flushableStorage = ((IFlushableLocalStorage) cache);
             IFastInsertLocalStorage targetStorage = ((IFastInsertLocalStorage) secondaryStorage);
-            synchronized (eventLock) {
+            synchronized (EVENT_LOCK) {
                 flushableStorage.flushEvents(targetStorage);
             }
             synchronized (cacheLock) {


### PR DESCRIPTION
https://swrvedev.jira.com/browse/SWRVE-14628
(Originally started here https://github.com/Swrve/swrve-android-sdk/pull/248)

Using one lock for sending events MemoryCachedLocalStorage.EVENT_LOCK.
The old SwrveEventsManager had its own lock which was causing dupe events when a flush was done whilst sending events at the same time.
