### PR TITLE
14646_device_info_sent_repeatedly

### DIFF
--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
@@ -464,7 +464,6 @@ public abstract class SwrveBase<T, C extends SwrveConfigBase> extends SwrveImp<T
         startCampaignsAndResourcesTimer(true);
         disableAutoShowAfterDelay();
 
-        queueDeviceInfoNow(false);
         long currentTime = getSessionTime();
         // Session management
         if (currentTime > lastSessionTick) {

--- a/SwrveSDKTest/src/test/java/com/swrve/sdk/ConversationUnitTest.java
+++ b/SwrveSDKTest/src/test/java/com/swrve/sdk/ConversationUnitTest.java
@@ -13,6 +13,8 @@ import com.swrve.sdk.conversations.engine.model.ConversationPage;
 import com.swrve.sdk.conversations.engine.model.UserInputResult;
 import com.swrve.sdk.messaging.SwrveBaseCampaign;
 import com.swrve.sdk.messaging.SwrveConversationCampaign;
+import com.swrve.sdk.rest.IRESTClient;
+import com.swrve.sdk.rest.IRESTResponseListener;
 
 import org.junit.After;
 import org.junit.Before;
@@ -46,6 +48,9 @@ public class ConversationUnitTest extends SwrveBaseTest {
         Swrve swrveReal = (Swrve) SwrveSDK.createInstance(mActivity, 1, "apiKey");
         swrveSpy = Mockito.spy(swrveReal);
         Mockito.doNothing().when(swrveSpy).downloadAssets(Mockito.anySet()); // assets are manually mocked
+        IRESTClient restClientSpy = Mockito.spy(swrveSpy.restClient);
+        swrveSpy.restClient = restClientSpy;
+        Mockito.doNothing().when(restClientSpy).post(Mockito.anyString(), Mockito.anyString(), Mockito.any(IRESTResponseListener.class), Mockito.anyString());
         swrveSpy.init(mActivity);
     }
 

--- a/SwrveSDKTest/src/test/java/com/swrve/sdk/SwrveUnitTest.java
+++ b/SwrveSDKTest/src/test/java/com/swrve/sdk/SwrveUnitTest.java
@@ -12,6 +12,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
@@ -104,5 +105,20 @@ public class SwrveUnitTest {
         config.setUserId("forced");
         ISwrve swrve = SwrveSDK.createInstance(mActivity, 1, "apiKey", config);
         assertEquals("forced", swrve.getUserId());
+    }
+
+    @Test
+    public void testDeviceInfoQueued() {
+        Swrve swrveReal = (Swrve) SwrveSDK.createInstance(mActivity, 1, "apiKey");
+        Swrve swrveSpy = Mockito.spy(swrveReal);
+        Mockito.verify(swrveSpy, Mockito.atMost(0)).queueDeviceInfoNow(Mockito.anyBoolean()); // device info not queued
+        swrveSpy.onCreate(mActivity);
+        Mockito.verify(swrveSpy, Mockito.atMost(1)).queueDeviceInfoNow(Mockito.anyBoolean()); // device info queued once upon init
+
+        swrveSpy.onCreate(mActivity);
+        Mockito.verify(swrveSpy, Mockito.atMost(1)).queueDeviceInfoNow(Mockito.anyBoolean()); // device info not queued, because sdk already initialised
+
+        swrveSpy.onResume(mActivity);
+        Mockito.verify(swrveSpy, Mockito.atMost(1)).queueDeviceInfoNow(Mockito.anyBoolean()); // device info not queued, because sdk already initialised
     }
 }

--- a/SwrveSDKTest/src/testGoogle/java/com/swrve/sdk/SwrveGoogleUnitTest.java
+++ b/SwrveSDKTest/src/testGoogle/java/com/swrve/sdk/SwrveGoogleUnitTest.java
@@ -1,0 +1,46 @@
+package com.swrve.sdk;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+
+public class SwrveGoogleUnitTest extends SwrveBaseTest {
+
+    private Swrve swrveSpy;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        Swrve swrveReal = (Swrve) SwrveSDK.createInstance(mActivity, 1, "apiKey");
+        swrveSpy = Mockito.spy(swrveReal);
+        swrveSpy.init(mActivity);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        swrveSpy.shutdown();
+        SwrveTestUtils.removeSwrveSDKSingletonInstance();
+    }
+
+    @Test
+    public void testSetRegistrationId() throws Exception {
+        Mockito.verify(swrveSpy, Mockito.atMost(1)).queueDeviceInfoNow(Mockito.anyBoolean()); // device info queued once upon init
+
+        swrveSpy.setRegistrationId("reg1");
+        assertEquals("reg1", swrveSpy.getRegistrationId());
+        Mockito.verify(swrveSpy, Mockito.atMost(2)).queueDeviceInfoNow(Mockito.anyBoolean()); // device info queued again so atMost== 2
+
+        swrveSpy.setRegistrationId("reg1");
+        assertEquals("reg1", swrveSpy.getRegistrationId());
+        Mockito.verify(swrveSpy, Mockito.atMost(2)).queueDeviceInfoNow(Mockito.anyBoolean()); // device info NOT queued again because the regId has NOT changed so remains atMost== 2
+
+        swrveSpy.setRegistrationId("reg2");
+        assertEquals("reg2", swrveSpy.getRegistrationId());
+        Mockito.verify(swrveSpy, Mockito.atMost(3)).queueDeviceInfoNow(Mockito.anyBoolean()); // device info queued again because the regId has changed so atMost== 3
+    }
+
+}


### PR DESCRIPTION
https://swrvedev.jira.com/browse/SWRVE-14646

Device info is queued at session start and when reg id changes, instead of every onResume

@Sergio-Mira small one please