### PR TITLE
13527_send_swrve_engaged_event

### DIFF
--- a/SwrveSDK/src/google/AndroidManifest.xml
+++ b/SwrveSDK/src/google/AndroidManifest.xml
@@ -15,5 +15,9 @@
             android:name="com.swrve.sdk.SwrvePushEngageReceiver"
             android:exported="true" />
 
+        <receiver
+            android:name="com.swrve.sdk.SwrveEngageEventSender"
+            android:exported="true" />
+
     </application>
 </manifest>

--- a/SwrveSDK/src/google/java/com/swrve/sdk/SwrveEngageEventSender.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/SwrveEngageEventSender.java
@@ -18,18 +18,6 @@ public class SwrveEngageEventSender extends BroadcastReceiver {
     private static final String LOG_TAG = "SwrveGcm";
     private Context context;
 
-    /**
-     * Called to process the engaged event and send to Swrve
-     *
-     * @param context android context
-     * @param pushId  The push id for engagement
-     */
-    public static void send(Context context, String pushId) {
-        Intent intent = new Intent(context, SwrveEngageEventSender.class);
-        intent.putExtra(SwrveGcmConstants.SWRVE_TRACKING_KEY, pushId);
-        context.sendBroadcast(intent);
-    }
-
     @Override
     public void onReceive(Context context, Intent intent) {
         try {

--- a/SwrveSDK/src/google/java/com/swrve/sdk/SwrveEngageEventSender.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/SwrveEngageEventSender.java
@@ -1,0 +1,62 @@
+package com.swrve.sdk;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.swrve.sdk.gcm.SwrveGcmConstants;
+
+import org.json.JSONException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SwrveEngageEventSender extends BroadcastReceiver {
+
+    private static final String LOG_TAG = "SwrveGcm";
+    private Context context;
+
+    /**
+     * Called to process the engaged event and send to Swrve
+     *
+     * @param context android context
+     * @param pushId  The push id for engagement
+     */
+    public static void send(Context context, String pushId) {
+        Intent intent = new Intent(context, SwrveEngageEventSender.class);
+        intent.putExtra(SwrveGcmConstants.SWRVE_TRACKING_KEY, pushId);
+        context.sendBroadcast(intent);
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        try {
+            this.context = context;
+            Bundle extras = intent.getExtras();
+            if (extras != null && !extras.isEmpty()) {
+                Object rawId = extras.get(SwrveGcmConstants.SWRVE_TRACKING_KEY);
+                String msgId = (rawId != null) ? rawId.toString() : null;
+                if (!SwrveHelper.isNullOrEmpty(msgId)) {
+                    String eventName = "Swrve.Messages.Push-" + msgId + ".engaged";
+                    SwrveLogger.d(LOG_TAG, "SwrveEngageEventSender: Sending engaged event:" + eventName);
+                    sendEngagedEvent(eventName);
+                }
+            }
+        } catch (Exception ex) {
+            SwrveLogger.e(LOG_TAG, "SwrveEngageEventSender. Error sending engaged event. Intent:" + intent, ex);
+        }
+    }
+
+    private void sendEngagedEvent(String name) throws JSONException {
+        Swrve swrve = (Swrve) SwrveSDK.getInstance();
+        ArrayList<String> events = new ArrayList<>();
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("name", name);
+        String eventString = EventHelper.eventAsJSON("event", parameters, swrve.getNextSequenceNumber());
+        events.add(eventString);
+        swrve.sendEventsWakefully(context, events);
+    }
+
+}

--- a/SwrveSDK/src/google/java/com/swrve/sdk/SwrvePushEngageReceiver.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/SwrvePushEngageReceiver.java
@@ -40,7 +40,7 @@ public class SwrvePushEngageReceiver extends BroadcastReceiver {
                     String msgId = (rawId != null) ? rawId.toString() : null;
                     if (!SwrveHelper.isNullOrEmpty(msgId)) {
                         SwrveLogger.d(LOG_TAG, "Found engaged event:" + msgId);
-                        SwrveEngageEventSender.send(context, msgId);
+                        SwrveSDK.send(context, msgId);
 
                         if(msg.containsKey(SwrveGcmConstants.DEEPLINK_KEY)) {
                             openDeeplink(msg);

--- a/SwrveSDK/src/google/java/com/swrve/sdk/SwrvePushEngageReceiver.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/SwrvePushEngageReceiver.java
@@ -40,7 +40,7 @@ public class SwrvePushEngageReceiver extends BroadcastReceiver {
                     String msgId = (rawId != null) ? rawId.toString() : null;
                     if (!SwrveHelper.isNullOrEmpty(msgId)) {
                         SwrveLogger.d(LOG_TAG, "Found engaged event:" + msgId);
-                        SwrveSDK.send(context, msgId);
+                        SwrveSDK.sendPushEngagedEvent(context, msgId);
 
                         if(msg.containsKey(SwrveGcmConstants.DEEPLINK_KEY)) {
                             openDeeplink(msg);

--- a/SwrveSDK/src/google/java/com/swrve/sdk/SwrvePushEngageReceiver.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/SwrvePushEngageReceiver.java
@@ -9,12 +9,7 @@ import android.os.Bundle;
 import com.swrve.sdk.gcm.SwrveGcmConstants;
 import com.swrve.sdk.gcm.SwrveGcmNotification;
 
-import org.json.JSONException;
-
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 
 public class SwrvePushEngageReceiver extends BroadcastReceiver {
 
@@ -44,9 +39,9 @@ public class SwrvePushEngageReceiver extends BroadcastReceiver {
                     Object rawId = msg.get(SwrveGcmConstants.SWRVE_TRACKING_KEY);
                     String msgId = (rawId != null) ? rawId.toString() : null;
                     if (!SwrveHelper.isNullOrEmpty(msgId)) {
-                        String eventName = "Swrve.Messages.Push-" + msgId + ".engaged";
-                        SwrveLogger.d(LOG_TAG, "GCM engaged, sending event:" + eventName);
-                        sendEngagedEvent(eventName);
+                        SwrveLogger.d(LOG_TAG, "Found engaged event:" + msgId);
+                        SwrveEngageEventSender.send(context, msgId);
+
                         if(msg.containsKey(SwrveGcmConstants.DEEPLINK_KEY)) {
                             openDeeplink(msg);
                         } else {
@@ -59,20 +54,6 @@ public class SwrvePushEngageReceiver extends BroadcastReceiver {
                     }
                 }
             }
-        }
-    }
-
-    private void sendEngagedEvent(String name) {
-        String eventString = "";
-        try {
-            ArrayList<String> events = new ArrayList<>();
-            Map<String, Object> parameters = new HashMap<>();
-            parameters.put("name", name);
-            eventString = EventHelper.eventAsJSON("event", parameters, swrve.getNextSequenceNumber());
-            events.add(eventString);
-            swrve.sendEventsWakefully(context, events);
-        } catch (JSONException e) {
-            SwrveLogger.e(LOG_TAG, "SwrvePushEngageReceiver. Could not send the engaged event:" + eventString, e);
         }
     }
 

--- a/SwrveSDK/src/google/java/com/swrve/sdk/SwrveSDK.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/SwrveSDK.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 
 import com.swrve.sdk.config.SwrveConfig;
 import com.swrve.sdk.gcm.ISwrvePushNotificationListener;
+import com.swrve.sdk.gcm.SwrveGcmConstants;
 
 public class SwrveSDK extends SwrveSDKBase {
 
@@ -133,5 +134,18 @@ public class SwrveSDK extends SwrveSDKBase {
     public static void setRegistrationId(String registrationId) {
         checkInstanceCreated();
         ((ISwrve) instance).setRegistrationId(registrationId);
+    }
+
+    /**
+     * Called to process the engaged event and send to Swrve
+     *
+     * @param context android context
+     * @param pushId  The push id for engagement
+     */
+    public static void send(Context context, String pushId) {
+        checkInstanceCreated();
+        Intent intent = new Intent(context, SwrveEngageEventSender.class);
+        intent.putExtra(SwrveGcmConstants.SWRVE_TRACKING_KEY, pushId);
+        context.sendBroadcast(intent);
     }
 }

--- a/SwrveSDK/src/google/java/com/swrve/sdk/SwrveSDK.java
+++ b/SwrveSDK/src/google/java/com/swrve/sdk/SwrveSDK.java
@@ -137,12 +137,12 @@ public class SwrveSDK extends SwrveSDKBase {
     }
 
     /**
-     * Called to process the engaged event and send to Swrve
+     * Called to send the push engaged event to Swrve.
      *
      * @param context android context
      * @param pushId  The push id for engagement
      */
-    public static void send(Context context, String pushId) {
+    public static void sendPushEngagedEvent(Context context, String pushId) {
         checkInstanceCreated();
         Intent intent = new Intent(context, SwrveEngageEventSender.class);
         intent.putExtra(SwrveGcmConstants.SWRVE_TRACKING_KEY, pushId);

--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveWakefulService.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveWakefulService.java
@@ -5,8 +5,6 @@ import android.content.Intent;
 
 import com.swrve.sdk.localstorage.MemoryCachedLocalStorage;
 import com.swrve.sdk.localstorage.SQLiteLocalStorage;
-import com.swrve.sdk.rest.IRESTClient;
-import com.swrve.sdk.rest.RESTClient;
 
 import java.util.ArrayList;
 
@@ -56,9 +54,8 @@ public class SwrveWakefulService extends IntentService {
     }
 
     private SwrveEventsManager getSendEventsManager(MemoryCachedLocalStorage memoryCachedLocalStorage){
-        IRESTClient restClient = new RESTClient(swrve.config.getHttpTimeout());
         short deviceId = EventHelper.getDeviceId(memoryCachedLocalStorage);
         String sessionToken = SwrveHelper.generateSessionToken(swrve.apiKey, swrve.appId, swrve.userId);
-        return new SwrveEventsManagerImp(swrve.config, restClient, swrve.userId, swrve.appVersion, sessionToken, deviceId);
+        return new SwrveEventsManagerImp(swrve.config, swrve.restClient, swrve.userId, swrve.appVersion, sessionToken, deviceId);
     }
 }

--- a/SwrveSDKTest/src/testGoogle/java/com/swrve/sdk/SwrveEngageEventSenderTest.java
+++ b/SwrveSDKTest/src/testGoogle/java/com/swrve/sdk/SwrveEngageEventSenderTest.java
@@ -65,7 +65,7 @@ public class SwrveEngageEventSenderTest extends SwrveBaseTest {
     }
 
     @Test
-    public void testReceiverOpenDeeplink() throws Exception {
+    public void testEventQueued() throws Exception {
         Intent intent = new Intent();
         intent.putExtra(SwrveGcmConstants.SWRVE_TRACKING_KEY, "4567");
 

--- a/SwrveSDKTest/src/testGoogle/java/com/swrve/sdk/SwrveEngageEventSenderTest.java
+++ b/SwrveSDKTest/src/testGoogle/java/com/swrve/sdk/SwrveEngageEventSenderTest.java
@@ -1,0 +1,108 @@
+package com.swrve.sdk;
+
+import android.content.Intent;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.swrve.sdk.config.SwrveConfig;
+import com.swrve.sdk.gcm.SwrveGcmConstants;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.Shadows;
+import org.robolectric.manifest.BroadcastReceiverData;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SwrveEngageEventSenderTest extends SwrveBaseTest {
+
+    private Swrve swrveSpy;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        shadowApplication = Shadows.shadowOf(RuntimeEnvironment.application);
+        SwrveConfig config = new SwrveConfig();
+        config.setSenderId("12345");
+        Swrve swrveReal = (Swrve) SwrveSDK.createInstance(mActivity, 1, "apiKey", config);
+        swrveSpy = Mockito.spy(swrveReal);
+        SwrveTestUtils.setSDKInstance(swrveSpy);
+        SwrveCommon.setSwrveCommon(swrveSpy);
+
+        Mockito.doNothing().when(swrveSpy).downloadAssets(Mockito.anySet()); // assets are manually mocked
+        Mockito.doReturn(true).when(swrveSpy).restClientExecutorExecute(Mockito.any(Runnable.class)); // disable rest
+        Mockito.doReturn(false).when(swrveSpy).isGooglePlayServicesAvailable(); // disable getting the regID
+
+        // do not init the sdk, as SwrvePushEngageReceiver can/will be executed cold
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        swrveSpy.shutdown();
+        SwrveTestUtils.removeSwrveSDKSingletonInstance();
+    }
+
+    @Test
+    public void testReceiverInManifest() throws Exception {
+        List<BroadcastReceiverData> receiverDataList = shadowApplication.getAppManifest().getBroadcastReceivers();
+        boolean inManifest = false;
+        for (BroadcastReceiverData receiverData : receiverDataList) {
+            if (receiverData.getClassName().equals("com.swrve.sdk.SwrveEngageEventSender")) {
+                inManifest = true;
+                break;
+            }
+        }
+        assertTrue(inManifest);
+    }
+
+    @Test
+    public void testReceiverOpenDeeplink() throws Exception {
+        Intent intent = new Intent();
+        intent.putExtra(SwrveGcmConstants.SWRVE_TRACKING_KEY, "4567");
+
+        SwrveEngageEventSender engageEventSender = new SwrveEngageEventSender();
+        engageEventSender.onReceive(mActivity, intent);
+
+        List<String> events = assertEventCount(1);
+        assertEngagedEvent(events.get(0), "Swrve.Messages.Push-4567.engaged");
+    }
+
+    private List<String> assertEventCount(int count) {
+        List<String> events = null;
+        List<Intent> broadcastIntents = mShadowActivity.getBroadcastIntents();
+        if (count == 0) {
+            assertEquals(0, broadcastIntents.size());
+        } else {
+            assertEquals(1, broadcastIntents.size());
+            assertEquals("com.swrve.sdk.SwrveWakefulReceiver", broadcastIntents.get(0).getComponent().getShortClassName());
+            events = (List) broadcastIntents.get(0).getExtras().get(SwrveWakefulService.EXTRA_EVENTS);
+            assertNotNull(events);
+            assertEquals(count, events.size());
+        }
+        return events;
+    }
+
+    private void assertEngagedEvent(String eventJson, String eventName) {
+        Gson gson = new Gson(); // eg: {"type":"event","time":1466519995192,"name":"Swrve.Messages.Push-1.engaged"}
+        Type type = new TypeToken<Map<String, String>>() {
+        }.getType();
+        Map<String, String> event = gson.fromJson(eventJson, type);
+        assertEquals(4, event.size());
+        assertTrue(event.containsKey("type"));
+        assertEquals("event", event.get("type"));
+        assertTrue(event.containsKey("name"));
+        assertEquals(eventName, event.get("name"));
+        assertTrue(event.containsKey("time"));
+        assertTrue(event.containsKey("seqnum"));
+    }
+
+}

--- a/SwrveSDKTest/src/testGoogle/java/com/swrve/sdk/SwrvePushEngageReceiverTest.java
+++ b/SwrveSDKTest/src/testGoogle/java/com/swrve/sdk/SwrvePushEngageReceiverTest.java
@@ -3,8 +3,6 @@ package com.swrve.sdk;
 import android.content.Intent;
 import android.os.Bundle;
 
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 import com.swrve.sdk.config.SwrveConfig;
 import com.swrve.sdk.gcm.SwrveGcmConstants;
 
@@ -16,9 +14,7 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.manifest.BroadcastReceiverData;
 
-import java.lang.reflect.Type;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -67,7 +63,6 @@ public class SwrvePushEngageReceiverTest extends SwrveBaseTest {
 
     @Test
     public void testReceiverOpenActivity() throws Exception {
-
         Intent intent = new Intent();
         Bundle extras = new Bundle();
         extras.putString("text", "validBundle");
@@ -81,13 +76,17 @@ public class SwrvePushEngageReceiverTest extends SwrveBaseTest {
         assertNotNull(nextIntent);
         assertEquals("com.swrve.sdk.test.MainActivity", nextIntent.getComponent().getClassName());
 
-        List<String> events = assertEventCount(1);
-        assertEngagedEvent(events.get(0), "Swrve.Messages.Push-1234.engaged");
+        List<Intent> broadcastIntents = mShadowActivity.getBroadcastIntents();
+        assertNotNull(broadcastIntents);
+        assertEquals(1, broadcastIntents.size());
+        assertEquals("com.swrve.sdk.SwrveEngageEventSender", broadcastIntents.get(0).getComponent().getShortClassName());
+        String pushId = (String) broadcastIntents.get(0).getExtras().get(SwrveGcmConstants.SWRVE_TRACKING_KEY);
+        assertNotNull(pushId);
+        assertEquals("1234", pushId);
     }
 
     @Test
     public void testReceiverOpenDeeplink() throws Exception {
-
         Intent intent = new Intent();
         Bundle extras = new Bundle();
         extras.putString("customdata", "customdata_value");
@@ -103,38 +102,6 @@ public class SwrvePushEngageReceiverTest extends SwrveBaseTest {
         assertEquals("swrve://deeplink/campaigns", nextStartedActivity.getData().toString());
         assertTrue(nextStartedActivity.hasExtra("customdata"));
         assertEquals("customdata_value", nextStartedActivity.getStringExtra("customdata"));
-
-        List<String> events = assertEventCount(1);
-        assertEngagedEvent(events.get(0), "Swrve.Messages.Push-4567.engaged");
-    }
-
-    private List<String> assertEventCount(int count) {
-        List<String> events = null;
-        List<Intent> broadcastIntents = mShadowActivity.getBroadcastIntents();
-        if (count == 0) {
-            assertEquals(0, broadcastIntents.size());
-        } else {
-            assertEquals(1, broadcastIntents.size());
-            assertEquals("com.swrve.sdk.SwrveWakefulReceiver", broadcastIntents.get(0).getComponent().getShortClassName());
-            events = (List) broadcastIntents.get(0).getExtras().get(SwrveWakefulService.EXTRA_EVENTS);
-            assertNotNull(events);
-            assertEquals(count, events.size());
-        }
-        return events;
-    }
-
-    private void assertEngagedEvent(String eventJson, String eventName) {
-        Gson gson = new Gson(); // eg: {"type":"event","time":1466519995192,"name":"Swrve.Messages.Push-1.engaged"}
-        Type type = new TypeToken<Map<String, String>>() {
-        }.getType();
-        Map<String, String> event = gson.fromJson(eventJson, type);
-        assertEquals(4, event.size());
-        assertTrue(event.containsKey("type"));
-        assertEquals("event", event.get("type"));
-        assertTrue(event.containsKey("name"));
-        assertEquals(eventName, event.get("name"));
-        assertTrue(event.containsKey("time"));
-        assertTrue(event.containsKey("seqnum"));
     }
 
 }


### PR DESCRIPTION
https://swrvedev.jira.com/browse/SWRVE-13527

Customers can now call the following line if handling push themselves so that the engagement is sent to Swrve:
SwrveEngageEventSender.send(context, msgId);