### PR TITLE
#267 Update proguard-rules.pro for rich push notification

### DIFF
--- a/SwrveSDKPush/proguard-rules.pro
+++ b/SwrveSDKPush/proguard-rules.pro
@@ -3,3 +3,4 @@
 -keepattributes *Annotation*
 -dontwarn sun.misc.Unsafe
 -keep class sun.misc.Unsafe { *; }
+-keep class com.swrve.sdk.model.** { *; }


### PR DESCRIPTION
Related issue : #267

add proguard settings for push notification models for gson.

RCA: proguard obfuscate gson models, so parsing jsons with rich push notification fail on obfuscated builds. It result with crash or fallback to simple notification.

FIX: add rule for models packge.