### PR TITLE
Fix warning from improper generated id usage

### DIFF
--- a/SwrveConversationSDK/src/main/res/drawable-xhdpi/swrve__rating_bar.xml
+++ b/SwrveConversationSDK/src/main/res/drawable-xhdpi/swrve__rating_bar.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android" >
-    <item android:id="@+android:id/background"
+    <item android:id="@android:id/background"
         android:drawable="@drawable/star_empty" />
-    <item android:id="@+android:id/secondaryProgress"
+    <item android:id="@android:id/secondaryProgress"
         android:drawable="@drawable/star_empty" />
-    <item android:id="@+android:id/progress"
+    <item android:id="@android:id/progress"
         android:drawable="@drawable/star_full" />
 </layer-list>


### PR DESCRIPTION
Warning fixed:
swrve-conversations-6.0.1.aar/1d7b6cc88cec23f4c0534e61a4b19c09/res/drawable-xhdpi-v4/swrve__rating_bar.xml:3: warn: generated id 'android:id/background' for external package 'android'.
swrve-conversations-6.0.1.aar/1d7b6cc88cec23f4c0534e61a4b19c09/res/drawable-xhdpi-v4/swrve__rating_bar.xml:7: warn: generated id 'android:id/progress' for external package 'android'.
swrve-conversations-6.0.1.aar/1d7b6cc88cec23f4c0534e61a4b19c09/res/drawable-xhdpi-v4/swrve__rating_bar.xml:5: warn: generated id 'android:id/secondaryProgress' for external package 'android'.