### PR TITLE
Fixing StrictMode

### DIFF
--- a/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
+++ b/SwrveSDK/src/main/java/com/swrve/sdk/SwrveBase.java
@@ -94,18 +94,28 @@ public abstract class SwrveBase<T, C extends SwrveConfigBase> extends SwrveImp<T
         return null;
     }
 
-    protected T onCreate(final Activity activity) throws IllegalArgumentException {
+    protected void onCreate(final Activity activity) throws IllegalArgumentException {
         if (destroyed) {
             destroyed = initialised = false;
             bindCounter.set(0);
         }
         if (!initialised) {
             // First time it is initialized
-            return init(activity);
+            initInBackground(activity);
+            return;
         }
 
         bindToContext(activity);
-        return (T) this;
+    }
+
+    private void initInBackground(Activity activity) {
+        Thread backgroundThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                init(activity);
+            }
+        });
+        backgroundThread.start();
     }
 
     protected synchronized T init(final Activity activity) throws IllegalArgumentException {

--- a/SwrveSDKTest/src/test/java/com/swrve/sdk/SwrveInstallReferrerReceiverTest.java
+++ b/SwrveSDKTest/src/test/java/com/swrve/sdk/SwrveInstallReferrerReceiverTest.java
@@ -58,6 +58,7 @@ public class SwrveInstallReferrerReceiverTest extends SwrveBaseTest {
         swrveSpy.initialised = false;
         swrveSpy.onCreate(mActivity);
         ArgumentCaptor<Map> attributesCaptor = ArgumentCaptor.forClass(Map.class);
+        waitUntilInitHasFinishedInBackground();
         Mockito.verify(swrveSpy, Mockito.atLeastOnce()).userUpdate(attributesCaptor.capture());
 
         Mockito.reset(swrveSpy);
@@ -65,5 +66,11 @@ public class SwrveInstallReferrerReceiverTest extends SwrveBaseTest {
         swrveSpy.initialised = false;
         swrveSpy.onCreate(mActivity); // calling init again should NOT increment counter
         Mockito.verify(swrveSpy, Mockito.never()).userUpdate(Mockito.anyMap());
+    }
+
+    private void waitUntilInitHasFinishedInBackground() throws InterruptedException {
+        do {
+            Thread.sleep(100);
+        } while (!swrveSpy.initialised);
     }
 }


### PR DESCRIPTION
In this PR I'm fixing [the StrictMode warnings](https://github.com/Swrve/swrve-android-sdk/issues/285) produced during Swrve initialization.

The idea is to move initialization process to a background thread. As suggested [here](https://developer.android.com/topic/performance/threads). Synchrony should be ensured since the init method is already synchronized.
